### PR TITLE
Enable production of PDF files as part of the preview target.

### DIFF
--- a/01-backup.md
+++ b/01-backup.md
@@ -2,6 +2,7 @@
 layout: page
 title: Version Control with Git
 subtitle: A Better Kind of Backup
+documentclass: scrartcl
 ---
 > ## Learning Objectives {.objectives}
 > 

--- a/01-backup.md
+++ b/01-backup.md
@@ -21,10 +21,7 @@ to keep track of what one person did and when.
 Even if you aren't collaborating with other people,
 version control is much better for this than this:
 
-<div>
-  <a href="http://www.phdcomics.com"><img src="fig/phd101212s.gif" alt="Piled Higher and Deeper by Jorge Cham, http://www.phdcomics.com" /></a>
-  <p>"Piled Higher and Deeper" by Jorge Cham, http://www.phdcomics.com</p>
-</div>
+[![Piled Higher and Deeper by Jorge Cham, http://www.phdcomics.com](fig/phd101212s.png)](http://www.phdcomics.com)
 
 ### Setting Up
 

--- a/02-collab.md
+++ b/02-collab.md
@@ -2,6 +2,7 @@
 layout: page
 title: Version Control with Git
 subtitle: Collaborating
+documentclass: scrartcl
 ---
 > ## Learning Objectives {.objectives}
 >

--- a/03-conflict.md
+++ b/03-conflict.md
@@ -2,6 +2,7 @@
 layout: page
 title: Version Control with Git
 subtitle: Conflicts
+documentclass: scrartcl
 ---
 > ## Learning Objectives {.objectives}
 >

--- a/04-open.md
+++ b/04-open.md
@@ -2,6 +2,7 @@
 layout: page
 title: Version Control with Git
 subtitle: Open Science
+documentclass: scrartcl
 ---
 > ## Learning Objectives {.objectives}
 >

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,10 @@ ALL_MD = $(wildcard *.md) $(DST_RMD)
 EXCLUDE_MD = README.md LAYOUT.md FAQ.md DESIGN.md
 SRC_MD = $(filter-out $(EXCLUDE_MD),$(ALL_MD))
 DST_HTML = $(patsubst %.md,%.html,$(SRC_MD))
+DST_PDF = $(patsubst %.md,%.pdf,$(SRC_MD))
 
 # All outputs.
-DST_ALL = $(DST_HTML)
+DST_ALL = $(DST_HTML) $(DST_PDF)
 
 # Pandoc filters.
 FILTERS = $(wildcard tools/filters/*.py)
@@ -44,6 +45,9 @@ motivation.html : motivation.md _layouts/slides.html
 	--filter=tools/filters/id4glossary.py \
 	$(INCLUDES) \
 	-o $@ $<
+
+%.pdf : %.md
+	pandoc -S -s --listings -o $@ $<
 
 ## unittest : Run unit test (for Python 2 and 3)
 unittest: tools/check.py tools/validation_helpers.py tools/test_check.py

--- a/instructors.md
+++ b/instructors.md
@@ -2,6 +2,7 @@
 layout: page
 title: Version Control with Git
 subtitle: Instructor's Guide
+documentclass: scrartcl
 ---
 ## Legend
 

--- a/motivation.md
+++ b/motivation.md
@@ -2,6 +2,7 @@
 layout: slides
 title: Version Control with Git
 subtitle: Motivation
+documentclass: scrartcl
 ---
 <section class="slide">
 ## Why Use Version Control?

--- a/reference.md
+++ b/reference.md
@@ -2,6 +2,7 @@
 layout: page
 title: Version Control with Git
 subtitle: Reference
+documentclass: scrartcl
 ---
 ## [A Better Kind of Backup](01-backup.html)
 


### PR DESCRIPTION
In order to produce handouts for my class I've added PDF generation to the preview target.  To get this working without adding in _yet another_ template (which would have to be maintained) I've chosen to add the "scrartcl" documentclass to the metadata for each document.  This chooses a LaTeX class that supports \subtitle, something automagically generated by the use of "subtitle:" in the document metadata.