### PR TITLE
Fixing glossary reference to "infective license".

### DIFF
--- a/04-open.md
+++ b/04-open.md
@@ -85,7 +85,7 @@ people can choose between the [GNU General Public License](http://opensource.org
 and licenses like the [MIT](http://opensource.org/licenses/MIT)
 and [BSD](http://opensource.org/licenses/BSD-2-Clause) licenses on the other.
 All of these licenses allow unrestricted sharing and modification of programs,
-but the GPL is [infective](reference.html#infective):
+but the GPL is [infective](reference.html#infective-license):
 anyone who distributes a modified version of the code
 (or anything that includes GPL'd code)
 must make *their* code freely available as well.


### PR DESCRIPTION
This fixes #31 - HTML will need to be regenerated.