### PR TITLE
remove color.ui settings

### DIFF
--- a/01-backup.md
+++ b/01-backup.md
@@ -35,7 +35,6 @@ Here's how Dracula sets up his new laptop:
 ~~~ {.bash}
 $ git config --global user.name "Vlad Dracula"
 $ git config --global user.email "vlad@tran.sylvan.ia"
-$ git config --global color.ui "auto"
 $ git config --global core.editor "nano"
 ~~~
 


### PR DESCRIPTION
As explained in the [git documentation](http://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#Colors-in-Git) the configuration variable `color.ui` is set to `auto` by default. There's no need to tell students to set this variable themselves.