### PR TITLE
Bring over Key Points from version 5.2

### DIFF
--- a/01-backup.md
+++ b/01-backup.md
@@ -804,6 +804,21 @@ $ git status --ignored
 nothing to commit, working directory clean
 ~~~
 
+> ## Key Points
+> *   Use `git config` to configure a user name, email address, editor, and other preferences once per machine.
+> *   `git init` initializes a repository.
+> *   `git status` shows the status of a repository.
+> *   Files can be stored in a project's working directory (which users see),
+>    the staging area (where the next commit is being built up)
+>    and the local repository (where revisions are permanently recorded).
+>*   `git add` puts files in the staging area.
+>*   `git commit` creates a snapshot of the staging area in the local repository.
+>*   Always write a log message when committing changes.
+>*   `git diff` displays differences between revisions.
+>*   `git checkout` recovers old versions of files.
+>*   The `.gitignore` file tells Git what files to ignore.
+
+
 > ## Committing Changes to Git {.challenge}
 >
 > Which command(s) below would save changes of `myfile.txt` to my local Git repository?


### PR DESCRIPTION
Having the key points i.e. summary before the challenges is helpful to the learners I believe. I have made a small change to the key points by replacing the word "snapshot" which is not defined anywhere else with "revisions", which is defined and reused a few times. If want to introduce to snapshots, perhaps better placed in the collaboration section. Finally some formatting of my markdown needs to occur as am not sure what to put in {.xxxxxx} for key points