### PR TITLE
Remove term *snapshot* from `reference.md`

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -11,9 +11,9 @@ subtitle: Reference
 *   `git status` shows the status of a repository.
 *   Files can be stored in a project's working directory (which users see),
     the staging area (where the next commit is being built up)
-    and the local repository (where snapshots are permanently recorded).
+    and the local repository (where revisions are permanently recorded).
 *   `git add` puts files in the staging area.
-*   `git commit` creates a snapshot of the staging area in the local repository.
+*   `git commit` save the revisions in the staging area to the local repository.
 *   Always write a log message when committing changes.
 *   `git diff` displays differences between revisions.
 *   `git checkout` recovers old versions of files.

--- a/reference.md
+++ b/reference.md
@@ -13,7 +13,7 @@ subtitle: Reference
     the staging area (where the next commit is being built up)
     and the local repository (where revisions are permanently recorded).
 *   `git add` puts files in the staging area.
-*   `git commit` save the revisions in the staging area to the local repository.
+*   `git commit` saves the revisions in the staging area to the local repository.
 *   Always write a log message when committing changes.
 *   `git diff` displays differences between revisions.
 *   `git checkout` recovers old versions of files.


### PR DESCRIPTION
the word *snapshot* is not defined anywhere in the lesson but does get used in `reference.md`. Rather than define *snapshot*, I have changed the text to used the defined term *revision*.  Another approach could be to use the term *change set* which is defined in the Glossary but doesn't appear anywhere else in the lesson.