### PR TITLE
Adds configuration for commonly used text editors

### DIFF
--- a/01-backup.md
+++ b/01-backup.md
@@ -35,12 +35,20 @@ Here's how Dracula sets up his new laptop:
 $ git config --global user.name "Vlad Dracula"
 $ git config --global user.email "vlad@tran.sylvan.ia"
 $ git config --global color.ui "auto"
-$ git config --global core.editor "nano"
 ~~~
 
-(Please use your own name and email address instead of Dracula's,
-and please make sure you choose an editor that's actually on your system,
-such as `notepad` on Windows.)
+(Please use your own name and email address instead of Dracula's.)
+
+He also has to configure his favorite text editor, following this table:
+
+| Editor             | Configuration command                            |
+|:-------------------|:-------------------------------------------------|
+| nano               | `$ git config --global core.editor "nano"`       |
+| Sublime Text (Mac) | `$ git config --global core.editor "subl -n -w"` |
+| Text Wrangler      | `$ git config --global core.editor "edit -w"`    |
+| Sublime Text (Win) | `$ git config --global core.editor "'c:/program files/sublime text 2/sublime_text.exe' -w"` |
+| Notepad++          | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
+| Kate (Linux)       | `$ git config --global core.editor "kate"`       |
 
 Git commands are written `git verb`,
 where `verb` is what we actually want it to do.

--- a/01-backup.md
+++ b/01-backup.md
@@ -47,8 +47,9 @@ He also has to set his favorite text editor, following this table:
 | Text Wrangler      | `$ git config --global core.editor "edit -w"`    |
 | Sublime Text (Mac) | `$ git config --global core.editor "subl -n -w"` |
 | Sublime Text (Win) | `$ git config --global core.editor "'c:/program files/sublime text 2/sublime_text.exe' -w"` |
-| Notepad++          | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
-| Kate               | `$ git config --global core.editor "kate"`       |
+| Notepad++ (Win)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
+| Kate (Linux)       | `$ git config --global core.editor "kate"`       |
+| Gedit              | `$ git config --global core.editor "gedit -s"`   |
 
 Git commands are written `git verb`,
 where `verb` is what we actually want it to do.

--- a/01-backup.md
+++ b/01-backup.md
@@ -39,7 +39,7 @@ $ git config --global color.ui "auto"
 
 (Please use your own name and email address instead of Dracula's.)
 
-He also has to configure his favorite text editor, following this table:
+He also has to set his favorite text editor, following this table:
 
 | Editor             | Configuration command                            |
 |:-------------------|:-------------------------------------------------|
@@ -62,6 +62,12 @@ we're telling Git:
 
 The four commands above only need to be run once:
 the flag `--global` tells Git to use the settings for every project on this machine.
+
+You can check your settings at any time:
+
+~~~ {.bash}
+$ git config --list
+~~~
 
 > ## Proxy {.callout}
 >

--- a/01-backup.md
+++ b/01-backup.md
@@ -49,7 +49,7 @@ He also has to set his favorite text editor, following this table:
 | Sublime Text (Win) | `$ git config --global core.editor "'c:/program files/sublime text 2/sublime_text.exe' -w"` |
 | Notepad++ (Win)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
 | Kate (Linux)       | `$ git config --global core.editor "kate"`       |
-| Gedit              | `$ git config --global core.editor "gedit -s"`   |
+| Gedit (Linux)      | `$ git config --global core.editor "gedit -s"`   |
 
 Git commands are written `git verb`,
 where `verb` is what we actually want it to do.

--- a/01-backup.md
+++ b/01-backup.md
@@ -43,7 +43,7 @@ He also has to set his favorite text editor, following this table:
 
 | Editor             | Configuration command                            |
 |:-------------------|:-------------------------------------------------|
-| nano               | `$ git config --global core.editor "nano"`       |
+| nano               | `$ git config --global core.editor "nano -w"`    |
 | Text Wrangler      | `$ git config --global core.editor "edit -w"`    |
 | Sublime Text (Mac) | `$ git config --global core.editor "subl -n -w"` |
 | Sublime Text (Win) | `$ git config --global core.editor "'c:/program files/sublime text 2/sublime_text.exe' -w"` |

--- a/01-backup.md
+++ b/01-backup.md
@@ -44,11 +44,11 @@ He also has to set his favorite text editor, following this table:
 | Editor             | Configuration command                            |
 |:-------------------|:-------------------------------------------------|
 | nano               | `$ git config --global core.editor "nano"`       |
-| Sublime Text (Mac) | `$ git config --global core.editor "subl -n -w"` |
 | Text Wrangler      | `$ git config --global core.editor "edit -w"`    |
+| Sublime Text (Mac) | `$ git config --global core.editor "subl -n -w"` |
 | Sublime Text (Win) | `$ git config --global core.editor "'c:/program files/sublime text 2/sublime_text.exe' -w"` |
 | Notepad++          | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
-| Kate (Linux)       | `$ git config --global core.editor "kate"`       |
+| Kate               | `$ git config --global core.editor "kate"`       |
 
 Git commands are written `git verb`,
 where `verb` is what we actually want it to do.


### PR DESCRIPTION
Adds a table in `01-backup.md` with proper `git config` for the following editors: nano, Sublime Text 2 (Win & Mac), Kate, Text Wrangler, and Notepad++. Not the prettiest thing, but I don't find any other way to have them all.  Fixes issue #39.

(I found the list in some notes I snatched long ago from one @karthik 's repos :-) )

I don't have access to a Windows machine: can someone else check the two Windows beauties? Do they need to modify the Windows path to get it working?