### PR TITLE
Reword repo inside repo challenge

### DIFF
--- a/01-backup.md
+++ b/01-backup.md
@@ -856,16 +856,19 @@ nothing to commit, working directory clean
 
 > ## Places to Create Git Repositories {.challenge}
 >
-> The following sequence of commands creates one Git repository inside another:
+> Dracula starts a new project, `moons`, related to his `planets` project.
+> Despite Wolfman's concerns, he enters the following sequence of commands to
+> create one Git repository inside another:
 > 
 > ~~~ {.bash}
-> cd           # return to home directory
-> mkdir alpha  # make a new directory alpha
-> cd alpha     # go into alpha
-> git init     # make the alpha directory a Git repository
-> mkdir beta   # make a sub-directory alpha/beta
-> cd beta      # go into alpha/beta
-> git init     # make the beta sub-directory a Git repository
+> cd             # return to home directory
+> mkdir planets  # make a new directory planets
+> cd planets     # go into planets
+> git init       # make the planets directory a Git repository
+> mkdir moons    # make a sub-directory planets/moons
+> cd moons       # go into planets/moons
+> git init       # make the moons sub-directory a Git repository
 > ~~~
 > 
 > Why is it a bad idea to do this?
+> How can Dracula "undo" his last `git init`?

--- a/instructors.md
+++ b/instructors.md
@@ -155,3 +155,18 @@ $ git commit
 ~~~ {.error}
 Aborting commit due to empty commit message.
 ~~~
+
+## [A Better Kind of Backup](01-backup.html)
+
+The challenge "Places to create repositories" tries to reinforce the idea that
+the `.git` folder contains the whole Git repo and deleting this folder *undoes*
+a `git init`. It also gives the learner the way to fix the common mistake of
+putting unwanted folders (like `Desktop`) under version control.
+
+Instead of removing the `.git` folder directly, you can choose to move
+it first to a safer directory and remove it from there:
+
+~~~ {.bash}
+mv .git temp_git
+rm -rf  temp_git
+~~~


### PR DESCRIPTION
Addresses the enhancement proposed in #33. See also the discussion on #54.

It makes the last challenge (why is bad to create a repo inside a repo) to follow a bit more the lesson theme. More importantly, it adds a question on what to do when you create a repo in the wrong place. This is something that happens quite commonly during this workshops, as learners, who are not yet proficient with the command line, put under version control the wrong folder, e.g. their whole home directory.