### PR TITLE
08-open.md: Don't list Google Code as a hosting option

### DIFF
--- a/08-open.md
+++ b/08-open.md
@@ -249,7 +249,6 @@ the option above or the option below.
 
 The third option is to use a public hosting service like [GitHub](http://github.com),
 [BitBucket](http://bitbucket.org),
-[Google Code](http://code.google.com),
 or [SourceForge](http://sourceforge.net).
 Each of these services provides a web interface that enables people to create, view, and edit their code repositories.
 These services also provide communication and project management tools including issue tracking, wiki pages,  email notifications, and code reviews.


### PR DESCRIPTION
They're shutting down, and pushing folks to GitHub, although they also
explain how to migrate to Bitbucket and SourceForge [1].

[1]: http://google-opensource.blogspot.de/2015/03/farewell-to-google-code.html