### PR TITLE
resize git_staging.svg to render better

### DIFF
--- a/fig/git_staging.svg
+++ b/fig/git_staging.svg
@@ -1,245 +1,625 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="3370.39px" height="2383.939px" viewBox="0 0 3370.39 2383.939" enable-background="new 0 0 3370.39 2383.939"
-	 xml:space="preserve">
-<g id="Layer_2">
-	<g>
-		<g>
-			<g>
-				<path d="M1623.162,1025.259c-0.068-40.184-8.343-83.315,4.544-122.34c6.533-19.782,20.001-35.506,37.983-45.857
-					c15.717-9.048,34.174-14.784,52.417-12.697c30.424,3.479,51.879,28.918,64.846,54.655c15.163,30.096,21.881,64.987,21.538,98.54
-					c-0.157,15.391-2.013,30.939-6.556,45.68c-4.516,14.658-12.619,27.519-22.983,38.775c-9.985,10.844-22.608,19.289-37.142,22.417
-					c-12.953,2.789-26.388,0.561-38.55-4.313c-28.092-11.258-49.952-35.874-65.798-60.883
-					c-17.348-27.38-29.346-59.449-31.216-91.976c-1.312-22.829,3.242-46.546,17.413-64.977c0.75-0.975-1.081-1.261-1.615-0.565
-					c-17.592,22.879-20.345,52.833-16.213,80.572c4.722,31.701,18.359,62.288,36.91,88.271
-					c16.368,22.926,38.597,44.569,66.021,53.226c25.771,8.137,51.068-0.288,69.773-19.082
-					c21.791-21.896,30.254-50.286,31.716-80.519c1.589-32.875-4.386-66.812-17.36-97.062
-					c-11.094-25.867-29.377-51.678-57.035-61.195c-31.602-10.874-70.137,5.112-90.97,29.554
-					c-15.839,18.583-20.543,43.388-21.643,67.099c-1.28,27.611,1.917,55.217,1.964,82.825
-					C1621.207,1026.419,1623.163,1026.122,1623.162,1025.259L1623.162,1025.259z"/>
-			</g>
-		</g>
-		<g>
-			<g>
-				<path d="M1714.553,1108.793c-11.154,46.729-25.67,92.883-33.411,140.364c-6.683,40.993-5.781,82.477,9.152,121.639
-					c12.063,31.637,32.017,59.707,54.324,84.91c0.431,0.486,2.276-0.205,1.797-0.746c-32.23-36.414-58.148-78.601-65.385-127.365
-					c-6.325-42.618,2.11-85.729,12.132-127.084c7.449-30.739,15.975-61.205,23.318-91.971
-					C1716.646,1107.85,1714.704,1108.156,1714.553,1108.793L1714.553,1108.793z"/>
-			</g>
-		</g>
-		<g>
-			<g>
-				<path d="M1748.064,1099.068c36.26,12.061,75.871,20.759,105.182,46.815c17.354,15.427,28.281,35.077,40.934,54.166
-					c16.538,24.953,32.345,50.591,43.781,78.342c6.244,15.156,10.852,30.978,13.256,47.2c0.07,0.472,2.016,0.047,1.932-0.518
-					c-4.355-29.384-16.176-56.796-30.503-82.609c-7.298-13.147-15.345-25.87-23.579-38.447
-					c-6.857-10.474-12.99-21.426-20.258-31.631c-11.113-15.605-24.229-29.461-40.438-39.818
-					c-14.873-9.504-31.625-15.615-48.279-21.179c-13.445-4.493-27.002-8.65-40.455-13.125
-					C1749.159,1098.106,1747.418,1098.854,1748.064,1099.068L1748.064,1099.068z"/>
-			</g>
-		</g>
-		<g>
-			<g>
-				<path d="M1731.285,1218.653c-17.191,31.296-26.57,67.91-26.734,103.605c-0.002,0.395,0.912,0.269,1.092,0.211
-					c22.919-7.286,40.885-24.871,57.565-41.416c19.101-18.944,37.932-40.351,62.687-52.003c1.218-0.573,0.096-1.168-0.756-0.768
-					c-22.439,10.562-40.047,29.003-57.313,46.315c-18.083,18.132-37.333,38.952-62.435,46.932c0.364,0.07,0.729,0.141,1.092,0.211
-					c0.163-35.46,9.523-71.977,26.598-103.061C1733.517,1217.887,1731.582,1218.114,1731.285,1218.653L1731.285,1218.653z"/>
-			</g>
-		</g>
-		<g>
-			<g>
-				<path d="M1812.09,1122.679c23.334,0,46.666,0,70,0c-0.18-0.365-0.36-0.73-0.541-1.095
-					c-40.502,34.119-59.17,85.215-90.168,126.818c-0.73,0.979,1.1,1.207,1.605,0.529c30.88-41.443,49.496-92.538,89.83-126.516
-					c0.666-0.561,0.191-1.095-0.54-1.095c-23.333,0-46.667,0-70,0C1811.193,1121.321,1810.777,1122.679,1812.09,1122.679
-					L1812.09,1122.679z"/>
-			</g>
-		</g>
-		<g>
-			<g>
-				<path d="M1752.049,1459.19c40.664-3.974,75.095-32.554,103.293-59.895c31.378-30.425,57.887-65.211,87.613-97.146
-					c0.77-0.827-1.119-0.758-1.545-0.301c-28.065,30.15-53.297,62.779-82.399,91.998c-28.714,28.828-64.417,60.164-106.692,64.296
-					C1751.383,1458.234,1750.707,1459.322,1752.049,1459.19L1752.049,1459.19z"/>
-			</g>
-		</g>
-	</g>
-	<polygon fill="#FFFFFF" stroke="#000000" stroke-width="2" stroke-miterlimit="10" points="1452.183,1605.333 1972.184,1085.333 
-		2298.834,1085.333 2298.834,1081.983 1775.484,1605.333 	"/>
-	<polyline fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" points="1532.183,1605.333 1532.183,788.667 
-		2055.516,265.333 2055.516,1085.333 2052.184,1085.333 	"/>
-</g>
-<g id="Layer_3">
-	<g id="Layer_4">
-		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="2366.8496" y1="1182.5" x2="2366.8496" y2="1495.3032">
-			<stop  offset="0.0982" style="stop-color:#C4C4C4"/>
-			<stop  offset="0.5326" style="stop-color:#686868"/>
-			<stop  offset="1" style="stop-color:#000000"/>
-		</linearGradient>
-		<path fill="url(#SVGID_1_)" stroke="#000000" stroke-width="3" stroke-miterlimit="10" d="M2083.517,1489.47
-			c0-52.467,126.853-95,283.333-95s283.334,42.533,283.334,95v5.833c0,0,0-11.992,0-17.666s0-202.334,0-202.334v2.197
-			c0-52.467-126.854-95-283.334-95s-283.333,42.533-283.333,95v-2.197c0,0,0,195.426,0,202.27c0,6.845,0,17.73,0,17.73V1489.47z"/>
-	</g>
-	<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="1040" y1="1396.9014" x2="1040" y2="1709.7041">
-		<stop  offset="0.0982" style="stop-color:#C4C4C4"/>
-		<stop  offset="0.5326" style="stop-color:#686868"/>
-		<stop  offset="1" style="stop-color:#000000"/>
-	</linearGradient>
-	<path fill="url(#SVGID_2_)" stroke="#000000" stroke-width="3" stroke-miterlimit="10" d="M756.667,1703.871
-		c0-52.467,126.853-95,283.333-95s283.334,42.533,283.334,95v5.833c0,0,0-11.992,0-17.666s0-202.334,0-202.334v2.197
-		c0-52.467-126.854-95-283.334-95s-283.333,42.533-283.333,95v-2.197c0,0,0,195.426,0,202.27c0,6.845,0,17.73,0,17.73V1703.871z"/>
-	<g>
-		
-			<line fill="none" stroke="#129F49" stroke-width="3" stroke-miterlimit="10" x1="839.183" y1="1533.303" x2="1015.183" y2="1487.303"/>
-		
-			<line fill="none" stroke="#129F49" stroke-width="3" stroke-miterlimit="10" x1="839.183" y1="1544.303" x2="1015.183" y2="1498.303"/>
-		
-			<line fill="none" stroke="#129F49" stroke-width="3" stroke-miterlimit="10" x1="839.183" y1="1564.303" x2="1015.183" y2="1518.303"/>
-		
-			<line fill="none" stroke="#129F49" stroke-width="3" stroke-miterlimit="10" x1="839.183" y1="1574.303" x2="1015.183" y2="1528.303"/>
-		
-			<line fill="none" stroke="#129F49" stroke-width="3" stroke-miterlimit="10" x1="839.183" y1="1584.303" x2="1015.183" y2="1538.303"/>
-	</g>
-	<g>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1463.303" x2="1239.517" y2="1515.303"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1473.303" x2="1239.517" y2="1525.303"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1483.303" x2="1239.517" y2="1535.303"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1523.303" x2="1239.517" y2="1575.303"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1533.303" x2="1239.517" y2="1585.303"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1543.303" x2="1239.517" y2="1595.303"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1553.303" x2="1239.517" y2="1605.303"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1563.303" x2="1239.517" y2="1615.303"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="1061.517" y1="1573.303" x2="1239.517" y2="1625.303"/>
-	</g>
-	<g>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="1927.939" x2="2344.184" y2="1979.939"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="1937.939" x2="2344.184" y2="1989.939"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="1947.939" x2="2344.184" y2="1999.939"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="1987.939" x2="2344.184" y2="2039.939"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="1997.939" x2="2344.184" y2="2049.939"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="2007.939" x2="2344.184" y2="2059.939"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="2017.939" x2="2344.184" y2="2069.939"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="2027.939" x2="2344.184" y2="2079.939"/>
-		<line stroke="#F04A44" stroke-width="3" stroke-miterlimit="10" x1="2166.184" y1="2037.939" x2="2344.184" y2="2089.939"/>
-	</g>
-</g>
-<g id="Layer_1">
-	<g>
-		<path fill="#FFFFFF" stroke="#000000" stroke-width="3" stroke-miterlimit="10" d="M1322.183,2145.939c0,0,0,196.659,0,202.334
-			s2,17.666,2,17.666c0,52.468-128.853,95-285.333,95c-156.481,0-285.333-42.532-285.333-95c0,0,2-10.886,2-17.729
-			c0-6.845,0-202.271,0-202.271c0,52.468,126.853,95,283.333,95C1195.331,2240.939,1322.183,2198.407,1322.183,2145.939z"/>
-		<rect x="927.183" y="2312.606" fill="none" width="223.333" height="53.333"/>
-		<text transform="matrix(1 0 0 1 952.2554 2343.6562)" font-family="'Consolas'" font-size="45">a2129cb</text>
-	</g>
-	<g>
-		<path fill="#FFFFFF" stroke="#000000" stroke-width="3" stroke-miterlimit="10" d="M1322.183,1926.939c0,0,0,196.659,0,202.334
-			s2,17.666,2,17.666c0,52.468-128.853,95-285.333,95c-156.481,0-285.333-42.532-285.333-95c0,0,2-10.886,2-17.729
-			c0-6.845,0-202.271,0-202.271c0,52.468,126.853,95,283.333,95C1195.331,2021.939,1322.183,1979.407,1322.183,1926.939z"/>
-		<rect x="927.183" y="2093.606" fill="none" width="223.333" height="53.333"/>
-		<text transform="matrix(1 0 0 1 952.2554 2124.6562)" font-family="'Consolas'" font-size="45">892134f</text>
-	</g>
-	<g>
-		<path fill="#FFFFFF" stroke="#000000" stroke-width="3" stroke-miterlimit="10" d="M1322.183,1707.939c0,0,0,196.659,0,202.334
-			s2,17.666,2,17.666c0,52.468-128.853,95-285.333,95c-156.481,0-285.333-42.532-285.333-95c0,0,2-10.886,2-17.729
-			c0-6.845,0-202.271,0-202.271c0,52.468,126.853,95,283.333,95C1195.331,1802.939,1322.183,1760.407,1322.183,1707.939z"/>
-		<rect x="927.183" y="1874.606" fill="none" width="223.333" height="53.333"/>
-		<text transform="matrix(1 0 0 1 952.2554 1905.6562)" font-family="'Consolas'" font-size="45">59e230a</text>
-	</g>
-	<g>
-		<path fill="#FFFFFF" stroke="#000000" stroke-width="3" stroke-miterlimit="10" d="M1322.183,1487.303c0,0,0,196.659,0,202.334
-			s2,17.666,2,17.666c0,52.468-128.853,95-285.333,95c-156.481,0-285.333-42.532-285.333-95c0,0,2-10.886,2-17.729
-			c0-6.845,0-202.271,0-202.271c0,52.468,126.853,95,283.333,95C1195.331,1582.303,1322.183,1539.771,1322.183,1487.303z"/>
-		<rect x="927.183" y="1653.97" fill="none" width="223.333" height="53.333"/>
-		<text transform="matrix(1 0 0 1 952.2554 1685.0195)" font-family="'Consolas'" font-size="45">3a54f76</text>
-	</g>
-	<g>
-		<path fill="#FFFFFF" stroke="#000000" stroke-width="3" stroke-miterlimit="10" d="M2650.184,1275.303c0,0,0,196.66,0,202.334
-			s2,17.666,2,17.666c0,52.468-128.854,95-285.334,95s-285.333-42.532-285.333-95c0,0,2-10.886,2-17.73c0-6.844,0-202.27,0-202.27
-			c0,52.467,126.853,95,283.333,95S2650.184,1327.77,2650.184,1275.303z"/>
-		<rect x="2255.184" y="1441.97" fill="none" width="223.333" height="53.333"/>
-		<text transform="matrix(1 0 0 1 2280.2559 1473.0195)" font-family="'Consolas'" font-size="45">43fe423</text>
-	</g>
-	<g>
-		<rect x="1016.412" y="1033.97" width="44.876" height="144.237"/>
-		<g>
-			<polygon points="989.27,1163.617 1039.123,1249.97 1088.986,1163.617 			"/>
-		</g>
-	</g>
-	<g>
-		<rect x="2344.135" y="1014" width="44.875" height="144.237"/>
-		<g>
-			<polygon points="2316.992,1143.647 2366.846,1230 2416.709,1143.647 			"/>
-		</g>
-	</g>
-	<g>
-		<rect x="2821.763" y="1393.951" fill="#4DA3DA" width="144.237" height="44.875"/>
-		<g>
-			<polygon fill="#4DA3DA" points="2836.353,1366.809 2750,1416.662 2836.353,1466.525 			"/>
-		</g>
-	</g>
-	<rect x="820" y="909.97" fill="none" width="440" height="180"/>
-	<text transform="matrix(1 0 0 1 971.2036 942.3242)"><tspan x="0" y="0" font-family="'Helvetica'" font-size="45">branch</tspan><tspan x="-5.427" y="54" font-family="'Consolas'" font-size="45">master</tspan></text>
-	<rect x="2146.572" y="952.333" fill="none" width="440" height="64"/>
-	<text transform="matrix(1 0 0 1 2242.7344 984.6875)" font-family="'Helvetica'" font-size="45">staging area</text>
-	<rect x="2638" y="1481.333" fill="none" width="440" height="64"/>
-	<text transform="matrix(1 0 0 1 2647.6992 1512.3828)" font-family="'Consolas'" font-size="45">git add file2.txt</text>
-	<g>
-		
-			<rect x="2639.726" y="1110.476" transform="matrix(0.2643 0.9644 -0.9644 0.2643 3099.1633 -1697.4526)" fill="#4DA3DA" width="44.875" height="144.237"/>
-		<g>
-			<polygon fill="#4DA3DA" points="2593.576,1149.98 2523.469,1220.883 2619.929,1246.152 			"/>
-		</g>
-	</g>
-	<g>
-		<polygon fill="#4DA3DA" points="2069.321,1918.87 2055.104,1961.434 1283.441,1683.494 1297.657,1640.932 		"/>
-		<g>
-			<polygon fill="#4DA3DA" points="2032.668,1982.556 2130.366,1962.627 2064.259,1887.976 			"/>
-		</g>
-	</g>
-	
-		<rect x="2433.176" y="1253.576" transform="matrix(0.9644 -0.2643 0.2643 0.9644 -245.417 746.868)" fill="none" width="440" height="64"/>
-	<text transform="matrix(0.9645 -0.2643 0.2643 0.9645 2450.0938 1340.2734)" font-family="'Consolas'" font-size="45">git add file1.txt</text>
-	
-		<rect x="1267.055" y="1843.297" transform="matrix(0.9416 0.3367 -0.3367 0.9416 728.3479 -449.4448)" fill="none" width="785.975" height="64"/>
-	<text transform="matrix(0.9416 0.3367 -0.3367 0.9416 1345.8921 1761.9014)" font-family="'Consolas'" font-size="45">git checkout HEAD file1.txt</text>
-	<polygon fill="none" points="1920,444 1646,718 1646,607 1920,333 	"/>
-	<text transform="matrix(1 -1 0 1 1684.0728 618.606)" font-family="'Consolas-Bold'" font-size="72">/.git</text>
-	<line fill="#4779BD" stroke="#4779BD" stroke-miterlimit="10" x1="2760" y1="1303" x2="2956" y2="1303"/>
-	<line fill="#4779BD" stroke="#4779BD" stroke-miterlimit="10" x1="2760" y1="1313" x2="2956" y2="1313"/>
-	<line fill="#4779BD" stroke="#4779BD" stroke-miterlimit="10" x1="2760" y1="1323" x2="2956" y2="1323"/>
-	<line fill="#4779BD" stroke="#4779BD" stroke-miterlimit="10" x1="2760" y1="1333" x2="2956" y2="1333"/>
-	<line fill="#4779BD" stroke="#4779BD" stroke-miterlimit="10" x1="2760" y1="1343" x2="2956" y2="1343"/>
-	<rect x="442.693" y="1546.775" fill="none" width="285.029" height="96.01"/>
-	<text transform="matrix(1 0 0 1 506.0361 1596.4551)" font-family="'Consolas'" font-size="72">HEAD</text>
-	<rect x="442.693" y="1791.966" fill="none" width="285.029" height="96.01"/>
-	<text transform="matrix(1 0 0 1 466.4502 1841.6445)" font-family="'Consolas'" font-size="72">HEAD~1</text>
-	<rect x="442.693" y="2038.435" fill="none" width="285.029" height="96.01"/>
-	<text transform="matrix(1 0 0 1 466.4502 2088.1133)" font-family="'Consolas'" font-size="72">HEAD~2</text>
-	<path fill="#4DA3DA" d="M2265.568,1507.944c-46.795,20.054-93.624,40.091-141.278,58.034c-11.216,4.223-22.482,8.307-33.798,12.254
-		c-0.45,0.157-0.9,0.313-1.352,0.471c-3.809,1.318-1.801,0.627,6.021-2.072c-1.352,0.465-2.705,0.925-4.059,1.386
-		c-2.705,0.92-5.415,1.827-8.127,2.729c-5.875,1.954-11.768,3.852-17.672,5.712c-22.976,7.239-46.198,13.686-69.619,19.316
-		c-12.086,2.905-24.232,5.556-36.419,8.004c-1.488,0.299-2.978,0.591-4.468,0.883c2.491-0.484,4.982-0.968,7.474-1.452
-		c-1,0.192-2,0.383-3.001,0.572c-3.02,0.573-6.043,1.126-9.068,1.671c-6.652,1.2-13.32,2.318-19.996,3.387
-		c-27.259,4.362-54.693,7.574-82.194,9.938c-14.938,1.283-29.9,2.271-44.872,3.055c-1.859,0.098-3.719,0.188-5.578,0.278
-		c-7.291,0.354,9.593-0.418,2.268-0.1c-3.699,0.161-7.4,0.301-11.101,0.434c-7.971,0.286-15.944,0.491-23.918,0.645
-		c-29.966,0.575-59.952,0.147-89.889-1.29c-22.423-1.077-44.814-2.804-67.138-5.167c-5.019-0.531-10.033-1.109-15.044-1.712
-		c11.839,1.423,1.375,0.152-1.263-0.191c-2.737-0.355-5.473-0.729-8.208-1.106c-10.766-1.488-21.504-3.179-32.214-5.031
-		c-38.884-6.726-77.399-16.015-114.737-28.843c2.378,0.82,4.757,1.642,7.135,2.463c-39.315-13.613-77.597-31.241-111.383-55.739
-		c1.729,1.259-4.814-6.226-4.814-6.226l63.512-2.947l-151.302-51.351l-30.607,115.455c0,0,35.258-37.649,40.269-33.417
-		c33.571,28.36,72.446,49.348,113.273,65.226c48.747,18.958,99.655,31.693,151.212,40.15c58.781,9.643,118.382,14.318,177.92,15.132
-		c62.347,0.852,125.025-2.097,186.949-9.467c53.632-6.384,106.95-16.67,159.059-30.888c49.227-13.432,97.458-30.566,144.912-49.257
-		c38.333-15.097,76.212-31.321,114.076-47.548c9.77-4.187,32.539-18.858,20.339-32.038c-5.139-5.552-13.868-7.046-20.985-7.295
-		C2285.572,1501.64,2275.025,1503.892,2265.568,1507.944L2265.568,1507.944z"/>
-	
-		<line fill="#FFFFFF" stroke="#927FBB" stroke-width="2" stroke-miterlimit="10" x1="2556.666" y1="1093.333" x2="2718" y2="1044.333"/>
-	
-		<line fill="#FFFFFF" stroke="#927FBB" stroke-width="2" stroke-miterlimit="10" x1="2556.666" y1="1103.333" x2="2718" y2="1054.333"/>
-	
-		<line fill="#FFFFFF" stroke="#927FBB" stroke-width="2" stroke-miterlimit="10" x1="2556.666" y1="1113.333" x2="2718" y2="1064.333"/>
-	
-		<line fill="#FFFFFF" stroke="#927FBB" stroke-width="2" stroke-miterlimit="10" x1="2556.666" y1="1133.333" x2="2718" y2="1084.333"/>
-	
-		<line fill="#FFFFFF" stroke="#927FBB" stroke-width="2" stroke-miterlimit="10" x1="2556.666" y1="1143.333" x2="2718" y2="1094.333"/>
-	<rect x="1524.181" y="1620.44" fill="none" width="440" height="64"/>
-	<text transform="matrix(1 0 0 1 1620.4746 1651.4902)" font-family="'Consolas'" font-size="45">git commit</text>
-</g>
-</svg>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   width="251.03062mm"
+   height="209.51903mm"
+   viewBox="0 0 889.4786 742.3903"
+   enable-background="new 0 0 3370.39 2383.939"
+   xml:space="preserve"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="git_staging.svg"><metadata
+     id="metadata270"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs268" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1781"
+     inkscape:window-height="1350"
+     id="namedview266"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="mm"
+     inkscape:zoom="1.1200099"
+     inkscape:cx="545.23923"
+     inkscape:cy="381.65982"
+     inkscape:window-x="885"
+     inkscape:window-y="654"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" /><g
+     id="Layer_2"
+     transform="matrix(0.33752373,0,0,0.33752373,-149.41939,-88.741328)"><g
+       id="g5"><g
+         id="g7"><g
+           id="g9"><path
+             d="m 1623.162,1025.259 c -0.068,-40.184 -8.343,-83.315 4.544,-122.34 6.533,-19.782 20.001,-35.506 37.983,-45.857 15.717,-9.048 34.174,-14.784 52.417,-12.697 30.424,3.479 51.879,28.918 64.846,54.655 15.163,30.096 21.881,64.987 21.538,98.54 -0.157,15.391 -2.013,30.939 -6.556,45.68 -4.516,14.658 -12.619,27.519 -22.983,38.775 -9.985,10.844 -22.608,19.289 -37.142,22.417 -12.953,2.789 -26.388,0.561 -38.55,-4.313 -28.092,-11.258 -49.952,-35.874 -65.798,-60.883 -17.348,-27.38 -29.346,-59.449 -31.216,-91.976 -1.312,-22.829 3.242,-46.546 17.413,-64.977 0.75,-0.975 -1.081,-1.261 -1.615,-0.565 -17.592,22.879 -20.345,52.833 -16.213,80.572 4.722,31.701 18.359,62.288 36.91,88.271 16.368,22.926 38.597,44.569 66.021,53.226 25.771,8.137 51.068,-0.288 69.773,-19.082 21.791,-21.896 30.254,-50.286 31.716,-80.519 1.589,-32.875 -4.386,-66.812 -17.36,-97.062 -11.094,-25.867 -29.377,-51.678 -57.035,-61.195 -31.602,-10.874 -70.137,5.112 -90.97,29.554 -15.839,18.583 -20.543,43.388 -21.643,67.099 -1.28,27.611 1.917,55.217 1.964,82.825 0,1.012 1.957,0.715 1.956,-0.148 l 0,0 z"
+             id="path11"
+             inkscape:connector-curvature="0" /></g></g><g
+         id="g13"><g
+           id="g15"><path
+             d="m 1714.553,1108.793 c -11.154,46.729 -25.67,92.883 -33.411,140.364 -6.683,40.993 -5.781,82.477 9.152,121.639 12.063,31.637 32.017,59.707 54.324,84.91 0.431,0.486 2.276,-0.205 1.797,-0.746 -32.23,-36.414 -58.148,-78.601 -65.385,-127.365 -6.325,-42.618 2.11,-85.729 12.132,-127.084 7.449,-30.739 15.975,-61.205 23.318,-91.971 0.166,-0.69 -1.776,-0.384 -1.927,0.253 l 0,0 z"
+             id="path17"
+             inkscape:connector-curvature="0" /></g></g><g
+         id="g19"><g
+           id="g21"><path
+             d="m 1748.064,1099.068 c 36.26,12.061 75.871,20.759 105.182,46.815 17.354,15.427 28.281,35.077 40.934,54.166 16.538,24.953 32.345,50.591 43.781,78.342 6.244,15.156 10.852,30.978 13.256,47.2 0.07,0.472 2.016,0.047 1.932,-0.518 -4.355,-29.384 -16.176,-56.796 -30.503,-82.609 -7.298,-13.147 -15.345,-25.87 -23.579,-38.447 -6.857,-10.474 -12.99,-21.426 -20.258,-31.631 -11.113,-15.605 -24.229,-29.461 -40.438,-39.818 -14.873,-9.504 -31.625,-15.615 -48.279,-21.179 -13.445,-4.493 -27.002,-8.65 -40.455,-13.125 -0.478,-0.158 -2.219,0.59 -1.573,0.804 l 0,0 z"
+             id="path23"
+             inkscape:connector-curvature="0" /></g></g><g
+         id="g25"><g
+           id="g27"><path
+             d="m 1731.285,1218.653 c -17.191,31.296 -26.57,67.91 -26.734,103.605 0,0.395 0.912,0.269 1.092,0.211 22.919,-7.286 40.885,-24.871 57.565,-41.416 19.101,-18.944 37.932,-40.351 62.687,-52.003 1.218,-0.573 0.096,-1.168 -0.756,-0.768 -22.439,10.562 -40.047,29.003 -57.313,46.315 -18.083,18.132 -37.333,38.952 -62.435,46.932 0.364,0.07 0.729,0.141 1.092,0.211 0.163,-35.46 9.523,-71.977 26.598,-103.061 0.436,-0.792 -1.499,-0.565 -1.796,-0.026 l 0,0 z"
+             id="path29"
+             inkscape:connector-curvature="0" /></g></g><g
+         id="g31"><g
+           id="g33"><path
+             d="m 1812.09,1122.679 c 23.334,0 46.666,0 70,0 -0.18,-0.365 -0.36,-0.73 -0.541,-1.095 -40.502,34.119 -59.17,85.215 -90.168,126.818 -0.73,0.979 1.1,1.207 1.605,0.529 30.88,-41.443 49.496,-92.538 89.83,-126.516 0.666,-0.561 0.191,-1.095 -0.54,-1.095 -23.333,0 -46.667,0 -70,0 -1.083,10e-4 -1.499,1.359 -0.186,1.359 l 0,0 z"
+             id="path35"
+             inkscape:connector-curvature="0" /></g></g><g
+         id="g37"><g
+           id="g39"><path
+             d="m 1752.049,1459.19 c 40.664,-3.974 75.095,-32.554 103.293,-59.895 31.378,-30.425 57.887,-65.211 87.613,-97.146 0.77,-0.827 -1.119,-0.758 -1.545,-0.301 -28.065,30.15 -53.297,62.779 -82.399,91.998 -28.714,28.828 -64.417,60.164 -106.692,64.296 -0.936,0.092 -1.612,1.18 -0.27,1.048 l 0,0 z"
+             id="path41"
+             inkscape:connector-curvature="0" /></g></g></g><polygon
+       stroke-miterlimit="10"
+       points="2298.834,1085.333 2298.834,1081.983 1775.484,1605.333 1452.183,1605.333 1972.184,1085.333 "
+       id="polygon43"
+       style="fill:#ffffff;stroke:#000000;stroke-width:2;stroke-miterlimit:10" /><polyline
+       stroke-miterlimit="10"
+       points="1532.183,1605.333 1532.183,788.667    2055.516,265.333 2055.516,1085.333 2052.184,1085.333  "
+       id="polyline45"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:10" /></g><g
+     id="Layer_3"
+     transform="matrix(0.33752373,0,0,0.33752373,-149.41939,-88.741328)"><g
+       id="Layer_4"><linearGradient
+         id="SVGID_1_"
+         gradientUnits="userSpaceOnUse"
+         x1="2366.8496"
+         y1="1182.5"
+         x2="2366.8496"
+         y2="1495.3032"><stop
+           offset="0.0982"
+           style="stop-color:#C4C4C4"
+           id="stop50" /><stop
+           offset="0.5326"
+           style="stop-color:#686868"
+           id="stop52" /><stop
+           offset="1"
+           style="stop-color:#000000"
+           id="stop54" /></linearGradient><path
+         stroke-miterlimit="10"
+         d="m 2083.517,1489.47 c 0,-52.467 126.853,-95 283.333,-95 156.48,0 283.334,42.533 283.334,95 l 0,5.833 c 0,0 0,-11.992 0,-17.666 0,-5.674 0,-202.334 0,-202.334 l 0,2.197 c 0,-52.467 -126.854,-95 -283.334,-95 -156.48,0 -283.333,42.533 -283.333,95 l 0,-2.197 c 0,0 0,195.426 0,202.27 0,6.845 0,17.73 0,17.73 l 0,-5.833 z"
+         id="path56"
+         style="fill:url(#SVGID_1_);stroke:#000000;stroke-width:3;stroke-miterlimit:10"
+         inkscape:connector-curvature="0" /></g><linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="1040"
+       y1="1396.9014"
+       x2="1040"
+       y2="1709.7041"><stop
+         offset="0.0982"
+         style="stop-color:#C4C4C4"
+         id="stop59" /><stop
+         offset="0.5326"
+         style="stop-color:#686868"
+         id="stop61" /><stop
+         offset="1"
+         style="stop-color:#000000"
+         id="stop63" /></linearGradient><path
+       stroke-miterlimit="10"
+       d="m 756.667,1703.871 c 0,-52.467 126.853,-95 283.333,-95 156.48,0 283.334,42.533 283.334,95 l 0,5.833 c 0,0 0,-11.992 0,-17.666 0,-5.674 0,-202.334 0,-202.334 l 0,2.197 c 0,-52.467 -126.854,-95 -283.334,-95 -156.48,0 -283.333,42.533 -283.333,95 l 0,-2.197 c 0,0 0,195.426 0,202.27 0,6.845 0,17.73 0,17.73 l 0,-5.833 z"
+       id="path65"
+       style="fill:url(#SVGID_2_);stroke:#000000;stroke-width:3;stroke-miterlimit:10"
+       inkscape:connector-curvature="0" /><g
+       id="g67"><line
+         stroke-miterlimit="10"
+         x1="839.18298"
+         y1="1533.303"
+         x2="1015.183"
+         y2="1487.303"
+         id="line69"
+         style="fill:none;stroke:#129f49;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="839.18298"
+         y1="1544.303"
+         x2="1015.183"
+         y2="1498.303"
+         id="line71"
+         style="fill:none;stroke:#129f49;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="839.18298"
+         y1="1564.303"
+         x2="1015.183"
+         y2="1518.303"
+         id="line73"
+         style="fill:none;stroke:#129f49;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="839.18298"
+         y1="1574.303"
+         x2="1015.183"
+         y2="1528.303"
+         id="line75"
+         style="fill:none;stroke:#129f49;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="839.18298"
+         y1="1584.303"
+         x2="1015.183"
+         y2="1538.303"
+         id="line77"
+         style="fill:none;stroke:#129f49;stroke-width:3;stroke-miterlimit:10" /></g><g
+       id="g79"><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1463.303"
+         x2="1239.517"
+         y2="1515.303"
+         id="line81"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1473.303"
+         x2="1239.517"
+         y2="1525.303"
+         id="line83"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1483.303"
+         x2="1239.517"
+         y2="1535.303"
+         id="line85"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1523.303"
+         x2="1239.517"
+         y2="1575.303"
+         id="line87"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1533.303"
+         x2="1239.517"
+         y2="1585.303"
+         id="line89"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1543.303"
+         x2="1239.517"
+         y2="1595.303"
+         id="line91"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1553.303"
+         x2="1239.517"
+         y2="1605.303"
+         id="line93"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1563.303"
+         x2="1239.517"
+         y2="1615.303"
+         id="line95"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="1061.517"
+         y1="1573.303"
+         x2="1239.517"
+         y2="1625.303"
+         id="line97"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /></g><g
+       id="g99"><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="1927.939"
+         x2="2344.1841"
+         y2="1979.939"
+         id="line101"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="1937.939"
+         x2="2344.1841"
+         y2="1989.939"
+         id="line103"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="1947.939"
+         x2="2344.1841"
+         y2="1999.939"
+         id="line105"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="1987.939"
+         x2="2344.1841"
+         y2="2039.939"
+         id="line107"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="1997.939"
+         x2="2344.1841"
+         y2="2049.939"
+         id="line109"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="2007.939"
+         x2="2344.1841"
+         y2="2059.939"
+         id="line111"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="2017.939"
+         x2="2344.1841"
+         y2="2069.939"
+         id="line113"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="2027.939"
+         x2="2344.1841"
+         y2="2079.939"
+         id="line115"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /><line
+         stroke-miterlimit="10"
+         x1="2166.1841"
+         y1="2037.939"
+         x2="2344.1841"
+         y2="2089.939"
+         id="line117"
+         style="stroke:#f04a44;stroke-width:3;stroke-miterlimit:10" /></g></g><g
+     id="Layer_1"
+     transform="matrix(0.33752373,0,0,0.33752373,-149.41939,-88.741328)"><g
+       id="g120"><path
+         stroke-miterlimit="10"
+         d="m 1322.183,2145.939 c 0,0 0,196.659 0,202.334 0,5.675 2,17.666 2,17.666 0,52.468 -128.853,95 -285.333,95 -156.481,0 -285.333,-42.532 -285.333,-95 0,0 2,-10.886 2,-17.729 0,-6.845 0,-202.271 0,-202.271 0,52.468 126.853,95 283.333,95 156.481,0 283.333,-42.532 283.333,-95 z"
+         id="path122"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke:#000000;stroke-width:3;stroke-miterlimit:10" /><rect
+         x="927.18298"
+         y="2312.606"
+         width="223.33299"
+         height="53.333"
+         id="rect124"
+         style="fill:none" /><text
+         transform="translate(952.2554,2343.6562)"
+         font-size="45"
+         id="text126"
+         style="font-size:45px;font-family:Consolas">a2129cb</text>
+</g><g
+       id="g128"><path
+         stroke-miterlimit="10"
+         d="m 1322.183,1926.939 c 0,0 0,196.659 0,202.334 0,5.675 2,17.666 2,17.666 0,52.468 -128.853,95 -285.333,95 -156.481,0 -285.333,-42.532 -285.333,-95 0,0 2,-10.886 2,-17.729 0,-6.845 0,-202.271 0,-202.271 0,52.468 126.853,95 283.333,95 156.481,0 283.333,-42.532 283.333,-95 z"
+         id="path130"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke:#000000;stroke-width:3;stroke-miterlimit:10" /><rect
+         x="927.18298"
+         y="2093.606"
+         width="223.33299"
+         height="53.333"
+         id="rect132"
+         style="fill:none" /><text
+         transform="translate(952.2554,2124.6562)"
+         font-size="45"
+         id="text134"
+         style="font-size:45px;font-family:Consolas">892134f</text>
+</g><g
+       id="g136"><path
+         stroke-miterlimit="10"
+         d="m 1322.183,1707.939 c 0,0 0,196.659 0,202.334 0,5.675 2,17.666 2,17.666 0,52.468 -128.853,95 -285.333,95 -156.481,0 -285.333,-42.532 -285.333,-95 0,0 2,-10.886 2,-17.729 0,-6.845 0,-202.271 0,-202.271 0,52.468 126.853,95 283.333,95 156.481,0 283.333,-42.532 283.333,-95 z"
+         id="path138"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke:#000000;stroke-width:3;stroke-miterlimit:10" /><rect
+         x="927.18298"
+         y="1874.606"
+         width="223.33299"
+         height="53.333"
+         id="rect140"
+         style="fill:none" /><text
+         transform="translate(952.2554,1905.6562)"
+         font-size="45"
+         id="text142"
+         style="font-size:45px;font-family:Consolas">59e230a</text>
+</g><g
+       id="g144"><path
+         stroke-miterlimit="10"
+         d="m 1322.183,1487.303 c 0,0 0,196.659 0,202.334 0,5.675 2,17.666 2,17.666 0,52.468 -128.853,95 -285.333,95 -156.481,0 -285.333,-42.532 -285.333,-95 0,0 2,-10.886 2,-17.729 0,-6.845 0,-202.271 0,-202.271 0,52.468 126.853,95 283.333,95 156.481,0 283.333,-42.532 283.333,-95 z"
+         id="path146"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke:#000000;stroke-width:3;stroke-miterlimit:10" /><rect
+         x="927.18298"
+         y="1653.97"
+         width="223.33299"
+         height="53.333"
+         id="rect148"
+         style="fill:none" /><text
+         transform="translate(952.2554,1685.0195)"
+         font-size="45"
+         id="text150"
+         style="font-size:45px;font-family:Consolas">3a54f76</text>
+</g><g
+       id="g152"><path
+         stroke-miterlimit="10"
+         d="m 2650.184,1275.303 c 0,0 0,196.66 0,202.334 0,5.674 2,17.666 2,17.666 0,52.468 -128.854,95 -285.334,95 -156.48,0 -285.333,-42.532 -285.333,-95 0,0 2,-10.886 2,-17.73 0,-6.844 0,-202.27 0,-202.27 0,52.467 126.853,95 283.333,95 156.48,0 283.334,-42.533 283.334,-95 z"
+         id="path154"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;stroke:#000000;stroke-width:3;stroke-miterlimit:10" /><rect
+         x="2255.1841"
+         y="1441.97"
+         width="223.33299"
+         height="53.333"
+         id="rect156"
+         style="fill:none" /><text
+         transform="translate(2280.2559,1473.0195)"
+         font-size="45"
+         id="text158"
+         style="font-size:45px;font-family:Consolas">43fe423</text>
+</g><g
+       id="g160"><rect
+         x="1016.412"
+         y="1033.97"
+         width="44.875999"
+         height="144.237"
+         id="rect162" /><g
+         id="g164"><polygon
+           points="1088.986,1163.617 989.27,1163.617 1039.123,1249.97 "
+           id="polygon166" /></g></g><g
+       id="g168"><rect
+         x="2344.135"
+         y="1014"
+         width="44.875"
+         height="144.237"
+         id="rect170" /><g
+         id="g172"><polygon
+           points="2416.709,1143.647 2316.992,1143.647 2366.846,1230 "
+           id="polygon174" /></g></g><g
+       id="g176"><rect
+         x="2821.7629"
+         y="1393.951"
+         width="144.237"
+         height="44.875"
+         id="rect178"
+         style="fill:#4da3da" /><g
+         id="g180"><polygon
+           points="2836.353,1466.525 2836.353,1366.809 2750,1416.662 "
+           id="polygon182"
+           style="fill:#4da3da" /></g></g><rect
+       x="820"
+       y="909.96997"
+       width="440"
+       height="180"
+       id="rect184"
+       style="fill:none" /><text
+       transform="translate(971.2036,942.3242)"
+       id="text186"><tspan
+         x="0"
+         y="0"
+         font-size="45"
+         id="tspan188"
+         style="font-size:45px;font-family:Helvetica">branch</tspan><tspan
+         x="-5.427"
+         y="54"
+         font-size="45"
+         id="tspan190"
+         style="font-size:45px;font-family:Consolas">master</tspan></text>
+<rect
+       x="2146.572"
+       y="952.33301"
+       width="440"
+       height="64"
+       id="rect192"
+       style="fill:none" /><text
+       transform="translate(2242.7344,984.6875)"
+       font-size="45"
+       id="text194"
+       style="font-size:45px;font-family:Helvetica">staging area</text>
+<rect
+       x="2638"
+       y="1481.333"
+       width="440"
+       height="64"
+       id="rect196"
+       style="fill:none" /><text
+       transform="translate(2647.6992,1512.3828)"
+       font-size="45"
+       id="text198"
+       style="font-size:45px;font-family:Consolas">git add file2.txt</text>
+<g
+       id="g200"><rect
+         x="2639.7261"
+         y="1110.476"
+         transform="matrix(0.2643,0.9644,-0.9644,0.2643,3099.1633,-1697.4526)"
+         width="44.875"
+         height="144.237"
+         id="rect202"
+         style="fill:#4da3da" /><g
+         id="g204"><polygon
+           points="2619.929,1246.152 2593.576,1149.98 2523.469,1220.883 "
+           id="polygon206"
+           style="fill:#4da3da" /></g></g><g
+       id="g208"><polygon
+         points="1297.657,1640.932 2069.321,1918.87 2055.104,1961.434 1283.441,1683.494 "
+         id="polygon210"
+         style="fill:#4da3da" /><g
+         id="g212"><polygon
+           points="2064.259,1887.976 2032.668,1982.556 2130.366,1962.627 "
+           id="polygon214"
+           style="fill:#4da3da" /></g></g><rect
+       x="2433.176"
+       y="1253.576"
+       transform="matrix(0.9644,-0.2643,0.2643,0.9644,-245.417,746.868)"
+       width="440"
+       height="64"
+       id="rect216"
+       style="fill:none" /><text
+       transform="matrix(0.9645,-0.2643,0.2643,0.9645,2450.0938,1340.2734)"
+       font-size="45"
+       id="text218"
+       style="font-size:45px;font-family:Consolas">git add file1.txt</text>
+<rect
+       x="1267.0551"
+       y="1843.297"
+       transform="matrix(0.9416,0.3367,-0.3367,0.9416,728.3479,-449.4448)"
+       width="785.97498"
+       height="64"
+       id="rect220"
+       style="fill:none" /><text
+       transform="matrix(0.9416,0.3367,-0.3367,0.9416,1345.8921,1761.9014)"
+       font-size="45"
+       id="text222"
+       style="font-size:45px;font-family:Consolas">git checkout HEAD file1.txt</text>
+<polygon
+       points="1920,333 1920,444 1646,718 1646,607 "
+       id="polygon224"
+       style="fill:none" /><text
+       transform="matrix(1,-1,0,1,1684.0728,618.606)"
+       font-size="72"
+       id="text226"
+       style="font-size:72px;font-family:Consolas-Bold">/.git</text>
+<line
+       stroke-miterlimit="10"
+       x1="2760"
+       y1="1303"
+       x2="2956"
+       y2="1303"
+       id="line228"
+       style="fill:#4779bd;stroke:#4779bd;stroke-miterlimit:10" /><line
+       stroke-miterlimit="10"
+       x1="2760"
+       y1="1313"
+       x2="2956"
+       y2="1313"
+       id="line230"
+       style="fill:#4779bd;stroke:#4779bd;stroke-miterlimit:10" /><line
+       stroke-miterlimit="10"
+       x1="2760"
+       y1="1323"
+       x2="2956"
+       y2="1323"
+       id="line232"
+       style="fill:#4779bd;stroke:#4779bd;stroke-miterlimit:10" /><line
+       stroke-miterlimit="10"
+       x1="2760"
+       y1="1333"
+       x2="2956"
+       y2="1333"
+       id="line234"
+       style="fill:#4779bd;stroke:#4779bd;stroke-miterlimit:10" /><line
+       stroke-miterlimit="10"
+       x1="2760"
+       y1="1343"
+       x2="2956"
+       y2="1343"
+       id="line236"
+       style="fill:#4779bd;stroke:#4779bd;stroke-miterlimit:10" /><rect
+       x="442.69299"
+       y="1546.775"
+       width="285.02899"
+       height="96.010002"
+       id="rect238"
+       style="fill:none" /><text
+       transform="translate(506.0361,1596.4551)"
+       font-size="72"
+       id="text240"
+       style="font-size:72px;font-family:Consolas">HEAD</text>
+<rect
+       x="442.69299"
+       y="1791.9659"
+       width="285.02899"
+       height="96.010002"
+       id="rect242"
+       style="fill:none" /><text
+       transform="translate(466.4502,1841.6445)"
+       font-size="72"
+       id="text244"
+       style="font-size:72px;font-family:Consolas">HEAD~1</text>
+<rect
+       x="442.69299"
+       y="2038.4351"
+       width="285.02899"
+       height="96.010002"
+       id="rect246"
+       style="fill:none" /><text
+       transform="translate(466.4502,2088.1133)"
+       font-size="72"
+       id="text248"
+       style="font-size:72px;font-family:Consolas">HEAD~2</text>
+<path
+       d="m 2265.568,1507.944 c -46.795,20.054 -93.624,40.091 -141.278,58.034 -11.216,4.223 -22.482,8.307 -33.798,12.254 -0.45,0.157 -0.9,0.313 -1.352,0.471 -3.809,1.318 -1.801,0.627 6.021,-2.072 -1.352,0.465 -2.705,0.925 -4.059,1.386 -2.705,0.92 -5.415,1.827 -8.127,2.729 -5.875,1.954 -11.768,3.852 -17.672,5.712 -22.976,7.239 -46.198,13.686 -69.619,19.316 -12.086,2.905 -24.232,5.556 -36.419,8.004 -1.488,0.299 -2.978,0.591 -4.468,0.883 2.491,-0.484 4.982,-0.968 7.474,-1.452 -1,0.192 -2,0.383 -3.001,0.572 -3.02,0.573 -6.043,1.126 -9.068,1.671 -6.652,1.2 -13.32,2.318 -19.996,3.387 -27.259,4.362 -54.693,7.574 -82.194,9.938 -14.938,1.283 -29.9,2.271 -44.872,3.055 -1.859,0.098 -3.719,0.188 -5.578,0.278 -7.291,0.354 9.593,-0.418 2.268,-0.1 -3.699,0.161 -7.4,0.301 -11.101,0.434 -7.971,0.286 -15.944,0.491 -23.918,0.645 -29.966,0.575 -59.952,0.147 -89.889,-1.29 -22.423,-1.077 -44.814,-2.804 -67.138,-5.167 -5.019,-0.531 -10.033,-1.109 -15.044,-1.712 11.839,1.423 1.375,0.152 -1.263,-0.191 -2.737,-0.355 -5.473,-0.729 -8.208,-1.106 -10.766,-1.488 -21.504,-3.179 -32.214,-5.031 -38.884,-6.726 -77.399,-16.015 -114.737,-28.843 2.378,0.82 4.757,1.642 7.135,2.463 -39.315,-13.613 -77.597,-31.241 -111.383,-55.739 1.729,1.259 -4.814,-6.226 -4.814,-6.226 l 63.512,-2.947 -151.302,-51.351 -30.607,115.455 c 0,0 35.258,-37.649 40.269,-33.417 33.571,28.36 72.446,49.348 113.273,65.226 48.747,18.958 99.655,31.693 151.212,40.15 58.781,9.643 118.382,14.318 177.92,15.132 62.347,0.852 125.025,-2.097 186.949,-9.467 53.632,-6.384 106.95,-16.67 159.059,-30.888 49.227,-13.432 97.458,-30.566 144.912,-49.257 38.333,-15.097 76.212,-31.321 114.076,-47.548 9.77,-4.187 32.539,-18.858 20.339,-32.038 -5.139,-5.552 -13.868,-7.046 -20.985,-7.295 -10.311,-0.362 -20.858,1.89 -30.315,5.942 l 0,0 z"
+       id="path250"
+       inkscape:connector-curvature="0"
+       style="fill:#4da3da" /><line
+       stroke-miterlimit="10"
+       x1="2556.666"
+       y1="1093.333"
+       x2="2718"
+       y2="1044.333"
+       id="line252"
+       style="fill:#ffffff;stroke:#927fbb;stroke-width:2;stroke-miterlimit:10" /><line
+       stroke-miterlimit="10"
+       x1="2556.666"
+       y1="1103.333"
+       x2="2718"
+       y2="1054.333"
+       id="line254"
+       style="fill:#ffffff;stroke:#927fbb;stroke-width:2;stroke-miterlimit:10" /><line
+       stroke-miterlimit="10"
+       x1="2556.666"
+       y1="1113.333"
+       x2="2718"
+       y2="1064.333"
+       id="line256"
+       style="fill:#ffffff;stroke:#927fbb;stroke-width:2;stroke-miterlimit:10" /><line
+       stroke-miterlimit="10"
+       x1="2556.666"
+       y1="1133.333"
+       x2="2718"
+       y2="1084.333"
+       id="line258"
+       style="fill:#ffffff;stroke:#927fbb;stroke-width:2;stroke-miterlimit:10" /><line
+       stroke-miterlimit="10"
+       x1="2556.666"
+       y1="1143.333"
+       x2="2718"
+       y2="1094.333"
+       id="line260"
+       style="fill:#ffffff;stroke:#927fbb;stroke-width:2;stroke-miterlimit:10" /><rect
+       x="1524.181"
+       y="1620.4399"
+       width="440"
+       height="64"
+       id="rect262"
+       style="fill:none" /><text
+       transform="translate(1620.4746,1651.4902)"
+       font-size="45"
+       id="text264"
+       style="font-size:45px;font-family:Consolas">git commit</text>
+</g></svg>


### PR DESCRIPTION
This graphic was drawing itself way too large on my PC, and going way outside of the box.  Resizing it here hopefully hasn't ruined how it appears on any other resolution displays (but please reject this PR if it does!)