### PR TITLE
Use snapshot analogy to clarify 'staging area'

### DIFF
--- a/04-changes.md
+++ b/04-changes.md
@@ -280,13 +280,14 @@ but not yet committed.
 > `git add` specifies *what* will go in a snapshot
 > (putting things in the staging area),
 > and `git commit` then *actually takes* the snapshot, and
-> copies it to long-term storage (as a commit).
+> makes a permanent record of it (as a commit).
 > If you don't have anything staged when you type `git commit`,
 > Git will prompt you to use `git commit -a` or `git commit --all`,
 > which is kind of like gathering *everyone* for the picture!
-> However, it's often considered bad practice to do this instead
-> of explicitly adding things to the staging area, because you might
-> commit changes you forgot you made. Try to stage things manually,
+> However, it's almost always better to
+> explicitly add things to the staging area, because you might
+> commit changes you forgot you made.
+> Try to stage things manually,
 > or you might find yourself searching for "git undo commit" more
 > than you would like!
 

--- a/04-changes.md
+++ b/04-changes.md
@@ -275,14 +275,14 @@ the current [change set](reference.html#change-set)
 but not yet committed.
 
 > ## Staging area {.callout}
-> If you think of git as taking snapshots of changes over the life of a
+> If you think of Git as taking snapshots of changes over the life of a
 > project,
 > `git add` specifies *what* will go in a snapshot
 > (putting things in the staging area),
 > and `git commit` then *actually takes* the snapshot, and
 > copies it to long-term storage (as a commit).
 > If you don't have anything staged when you type `git commit`,
-> git will prompt you to use `git commit -a` or `git commit --all`,
+> Git will prompt you to use `git commit -a` or `git commit --all`,
 > which is kind of like gathering *everyone* for the picture!
 > However, it's often considered bad practice to do this instead
 > of explicitly adding things to the staging area, because you might

--- a/04-changes.md
+++ b/04-changes.md
@@ -269,12 +269,16 @@ but *not* commit the work we're doing on the conclusion
 (which we haven't finished yet).
 
 To allow for this,
-Git has a special staging area
+Git has a special *staging area*
 where it keeps track of things that have been added to
 the current [change set](reference.html#change-set)
 but not yet committed.
-`git add` puts things in this area,
-and `git commit` then copies them to long-term storage (as a commit):
+If you think of git as taking snapshots of changes over the life of a
+project,
+`git add` specifies *what* will go in a snapshot
+(putting things in the staging area),
+and `git commit` then *actually takes* the snapshot and
+copies it to long-term storage (as a commit):
 
 ![The Git Staging Area](fig/git-staging-area.svg)
 

--- a/04-changes.md
+++ b/04-changes.md
@@ -286,7 +286,9 @@ but not yet committed.
 > which is kind of like gathering *everyone* for the picture!
 > However, it's almost always better to
 > explicitly add things to the staging area, because you might
-> commit changes you forgot you made.
+> commit changes you forgot you made. (Going back to snapshots,
+> you might get the extra with incomplete makeup walking on
+> the stage for the snapshot because you used `-a`!)
 > Try to stage things manually,
 > or you might find yourself searching for "git undo commit" more
 > than you would like!

--- a/04-changes.md
+++ b/04-changes.md
@@ -273,12 +273,22 @@ Git has a special *staging area*
 where it keeps track of things that have been added to
 the current [change set](reference.html#change-set)
 but not yet committed.
-If you think of git as taking snapshots of changes over the life of a
-project,
-`git add` specifies *what* will go in a snapshot
-(putting things in the staging area),
-and `git commit` then *actually takes* the snapshot and
-copies it to long-term storage (as a commit):
+
+> ## Staging area {.callout}
+> If you think of git as taking snapshots of changes over the life of a
+> project,
+> `git add` specifies *what* will go in a snapshot
+> (putting things in the staging area),
+> and `git commit` then *actually takes* the snapshot, and
+> copies it to long-term storage (as a commit).
+> If you don't have anything staged when you type `git commit`,
+> git will prompt you to use `git commit -a` or `git commit --all`,
+> which is kind of like gathering *everyone* for the picture!
+> However, it's often considered bad practice to do this instead
+> of explicitly adding things to the staging area, because you might
+> commit changes you forgot you made. Try to stage things manually,
+> or you might find yourself searching for "git undo commit" more
+> than you would like!
 
 ![The Git Staging Area](fig/git-staging-area.svg)
 


### PR DESCRIPTION
Someone asked me a question about the "staging area" vs "git commit -a" at a recent workshop, and I came up with the analogy of someone taking pictures for posterity. Then, "git add" gets the right people sitting in front of the stage for taking the picture, "git commit" actually takes the picture, and "git commit -a" says "Ok, now one with everyone!"

I think it worked pretty well. It doesn't look like the lesson covers "git commit -a" but I thought the analogy might be useful anyway to explain the staging area by itself.