### PR TITLE
Prefer commit to version or revision

### DIFF
--- a/04-changes.md
+++ b/04-changes.md
@@ -100,9 +100,9 @@ $ git commit -m "Start notes on Mars as a base"
 When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
 and stores a copy permanently inside the special `.git` directory.
-This permanent copy is called a [revision](reference.html#revision)
-and its short identifier is `f22b25e`
-(Your revision may have another identifier.)
+This permanent copy is called a [commit](reference.html#commit)
+(or [revision](reference.html#revision)) and its short identifier is `f22b25e`
+(Your commit may have another identifier.)
 
 We use the `-m` flag (for "message")
 to record a short, descriptive, and specific comment that will help us remember later on what we did and why.
@@ -140,14 +140,14 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
     Start notes on Mars as a base
 ~~~
 
-`git log` lists all revisions  made to a repository in reverse chronological order.
-The listing for each revision includes
-the revision's full identifier
+`git log` lists all commits  made to a repository in reverse chronological order.
+The listing for each commit includes
+the commit's full identifier
 (which starts with the same characters as
 the short identifier printed by the `git commit` command earlier),
-the revision's author,
+the commit's author,
 when it was created,
-and the log message Git was given when the revision was created.
+and the log message Git was given when the commit was created.
 
 > ## Where Are My Changes? {.callout}
 >

--- a/04-changes.md
+++ b/04-changes.md
@@ -218,9 +218,9 @@ If we break it down into pieces:
 
 1.  The first line tells us that Git is producing output similar to the Unix `diff` command
     comparing the old and new versions of the file.
-2.  The second line tells exactly which revisions of the file
+2.  The second line tells exactly which versions of the file
     Git is comparing;
-    `df0654a` and `315bf3a` are unique computer-generated labels for those revisions.
+    `df0654a` and `315bf3a` are unique computer-generated labels for those versions.
 3.  The third and fourth lines once again show the name of the file being changed.
 4.  The remaining lines are the most interesting, they show us the actual differences
     and the lines on which they occur.

--- a/05-history.md
+++ b/05-history.md
@@ -6,14 +6,13 @@ minutes: 25
 ---
 > ## Learning Objectives {.objectives}
 >
-> *   Identify and use Git revision numbers.
+> *   Identify and use Git commit numbers.
 > *   Compare various versions of tracked files.
 > *   Restore old versions of files.
 
-
 If we want to see what we changed at different steps, we can use `git diff`
 again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to old
-versions:
+commits:
 
 ~~~ {.bash}
 $ git diff HEAD~1 mars.txt
@@ -43,14 +42,14 @@ index df0654a..b36abfd 100644
 ~~~
 
 In this way,
-we can build up a chain of revisions.
+we can build up a chain of commits.
 The most recent end of the chain is referred to as `HEAD`;
-we can refer to previous revisions using the `~` notation,
+we can refer to previous commits using the `~` notation,
 so `HEAD~1` (pronounced "head minus one")
-means "the previous revision",
-while `HEAD~123` goes back 123 revisions from where we are now.
+means "the previous commit",
+while `HEAD~123` goes back 123 commits from where we are now.
 
-We can also refer to revisions using
+We can also refer to commits using
 those long strings of digits and letters
 that `git log` displays.
 These are unique IDs for the changes,
@@ -141,21 +140,21 @@ As you might guess from its name,
 `git checkout` checks out (i.e., restores) an old version of a file.
 In this case,
 we're telling Git that we want to recover the version of the file recorded in `HEAD`,
-which is the last saved revision.
+which is the last saved commit.
 If we want to go back even further,
-we can use a revision identifier instead:
+we can use a commit identifier instead:
 
 ~~~ {.bash}
 $ git checkout f22b25e mars.txt
 ~~~
 
 It's important to remember that
-we must use the revision number that identifies the state of the repository
+we must use the commit number that identifies the state of the repository
 *before* the change we're trying to undo.
-A common mistake is to use the revision number of
+A common mistake is to use the number of
 the commit in which we made the change we're trying to get rid of.
 In the example below, we want to retrieve the state from before the most
-recent commit (`HEAD~1`), which is revision `f22b25e`:
+recent commit (`HEAD~1`), which is commit `f22b25e`:
 
 ![Git Checkout](fig/git-checkout.svg)
 
@@ -178,7 +177,7 @@ So, to put it all together:
 > The double dash `--` is needed to separate the names of the files being recovered
 > from the command itself:
 > without it,
-> Git would try to use the name of the file as the revision identifier.
+> Git would try to use the name of the file as the commit identifier.
 
 The fact that files can be reverted one by one
 tends to change the way people organize their work.
@@ -196,7 +195,7 @@ moving backward and forward in time becomes much easier.
 > modifications she made this morning "broke" the script and it no longer runs. She has spent
 > ~ 1hr trying to fix it, with no luck...
 >
-> Luckily, she has been keeping track of her revisions using Git! Which commands below will
+> Luckily, she has been keeping track of her project's versions using Git! Which commands below will
 > let her recover the last committed version of her Python script called
 > `data_cruncher.py`?
 >
@@ -218,6 +217,6 @@ moving backward and forward in time becomes much easier.
 > 4. 
 >
 >     ~~~
->     $ git checkout <unique ID of last revision> data_cruncher.py
+>     $ git checkout <unique ID of last commit> data_cruncher.py
 >     ~~~
 > 5. Both 2 & 4

--- a/09-conflict.md
+++ b/09-conflict.md
@@ -151,7 +151,7 @@ Our change&mdash;the one in `HEAD`&mdash;is preceded by `<<<<<<<`.
 Git has then inserted `=======` as a separator between the conflicting changes
 and marked the end of the content downloaded from GitHub with `>>>>>>>`.
 (The string of letters and digits after that marker
-identifies the revision we've just downloaded.)
+identifies the commit we've just downloaded.)
 
 It is now up to us to edit this file to remove these markers
 and reconcile the changes.


### PR DESCRIPTION
We prefer to use only one word to mean a "recorded set of changes in a VC repo" and, by issue #133, that is commit. Version should be left for a general set of changes (not necessarily committed to a repo).