### PR TITLE
Quality Control Fixes and Title Changes

### DIFF
--- a/discussion.html
+++ b/discussion.html
@@ -63,7 +63,7 @@ $ <span class="kw">git</span> config --global --unset log.abbrevCommit
 $ <span class="kw">git</span> config --global --unset format.pretty</code></pre>
 <aside class="callout panel panel-info">
 <div class="panel-heading">
-<h2><span class="glyphicon glyphicon-pushpin"></span>Undoing Git Configuration Changes</h2>
+<h2><span class="glyphicon glyphicon-pushpin"></span>Version Controlling Your Git Configuration</h2>
 </div>
 <div class="panel-body">
 <p>You can use the <code>--unset</code> flag to delete unwanted options from <code>.gitconfig</code>. Another way to roll back changes is to store your <code>.gitconfig</code> using Git.</p>
@@ -109,107 +109,6 @@ index df0654a..315bf3a 100644
 <p>An uninformative <code>git diff</code> is not the only consequence of using Git on binary files. However, most of the other problems boil down to whether or not a good diff is possible.</p>
 <p>This isn’t to say you should <em>never</em> use Git on binary files. A rule of thumb is that it’s okay if the binary file won’t change very often, and if it does change, you don’t care about merging in small differences between versions.</p>
 <p>We’ve already seen how a word processed report will fail this test. An example that passes the test is a logo for your organization or project. Even though a logo will be stored in a binary format such as <code>jpg</code> or <code>png</code>, you can expect it will remain fairly static through the lifetime of your repository. On the rare occasion that branding does change, you will probably just want to replace the logo completely rather than merge little differences in.</p>
-<h2 id="removing-a-file">Removing a file</h2>
-<p>Adding and modifying files are not the only actions one might take when working on a project. It might be required to remove a file from the repository.</p>
-<p>Create a new file for the planet Nibiru:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">echo</span> <span class="st">&quot;This is another name for fake planet X&quot;</span> <span class="kw">&gt;</span> nibiru.txt</code></pre>
-<p>Now add to the repository like you have learned earlier:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add nibiru.txt
-$ <span class="kw">git</span> commit -m <span class="st">&#39;adding info on nibiru&#39;</span>
-$ <span class="kw">git</span> status</code></pre>
-<pre class="output"><code>On branch master
-nothing to commit, working directory clean</code></pre>
-<p>Nibiru is not a real planet. That was a silly idea. Let us remove it from the disk and let Git know about it:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> rm nibiru.txt
-$ <span class="kw">git</span> status</code></pre>
-<pre class="output"><code>On branch master
-Changes to be committed:
-   (use &quot;git reset HEAD &lt;file&gt;...&quot; to unstage)
-
-   deleted:    nibiru.txt
-</code></pre>
-<p>The change has been staged. Now commit the removal, and remove the file from the repository itself. Note that the file will be removed in the new commit. The previous commit will still have the file, if you were to retrieve that specific commit.</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&#39;Removing info on Nibiru.  It is not a real planet!&#39;</span></code></pre>
-<h2 id="removing-a-file-with-unix">Removing a File with Unix</h2>
-<p>Sometimes we migth forget to remove the file through Git. If you removed the file with Unix <code>rm</code> instead of using <code>git rm</code>, no worries, Git is smart enough to notice the missing file. Let us recreate the file and commit it again.</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">echo</span> <span class="st">&quot;This is another name for fake planet X&quot;</span> <span class="kw">&gt;</span> nibiru.txt
-$ <span class="kw">git</span> add nibiru.txt
-$ <span class="kw">git</span> commit -m <span class="st">&#39;adding nibiru again&#39;</span></code></pre>
-<p>Now we remove the file with Unix <code>rm</code>:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">rm</span> nibiru.txt
-$ <span class="kw">git</span> status</code></pre>
-<pre class="output"><code>On branch master
-Changes not staged for commit:
-   (use &quot;git add/rm &lt;file&gt;...&quot; to update what will be committed)
-   (use &quot;git checkout -- &lt;file&gt;...&quot; to discard changes in working directory)
-
-    deleted:    nibiru.txt
-
-no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)</code></pre>
-<p>See how Git has noticed that the file <code>nibiru.txt</code> has been removed from the disk. The next step is to “stage” the removal of the file from the repository. This is done with the command <code>git rm</code> just as before.</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> rm nibiru.txt
-$ <span class="kw">git</span> status</code></pre>
-<pre class="output"><code>On branch master
-Changes to be committed:
-   (use &quot;git reset HEAD &lt;file&gt;...&quot; to unstage)
-
-   deleted:    nibiru.txt
-</code></pre>
-<p>The change that was made in Unix has now been staged and needs to be committed.</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&#39;Removing info on Nibiru, again!&#39;</span></code></pre>
-<h2 id="renaming-a-file">Renaming a File</h2>
-<p>Another common change when working on a project is to rename a file.</p>
-<p>Create a file for the planet Krypton:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">echo</span> <span class="st">&quot;Superman&#39;s home planet&quot;</span> <span class="kw">&gt;</span> krypton.txt</code></pre>
-<p>Add it to the repository:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add krypton.txt
-$ <span class="kw">git</span> commit -m <span class="st">&#39;Adding planet Krypton&#39;</span></code></pre>
-<p>We all know that Superman moved to Earth. Not that he had much choice. Now his home planet is Earth.</p>
-<p>Rename the file <code>krypton.txt</code> to <code>earth.txt</code> with Git:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> mv krypton.txt earth.txt
-$ <span class="kw">git</span> status</code></pre>
-<pre class="output"><code># On branch master
-# Changes to be committed:
-#   (use &quot;git reset HEAD &lt;file&gt;...&quot; to unstage)
-#
-#   renamed:    krypton.txt -&gt; earth.txt
-#</code></pre>
-<p>The final step is commit our change to the repository:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&#39;Superman&#39;</span>s home is now Earth<span class="st">&#39;</span></code></pre>
-<h2 id="renaming-a-file-with-unix">Renaming a File with Unix</h2>
-<p>If you forgot to use Git and you used Unix <code>mv</code> instead of <code>git mv</code>, you will have a touch more work to do but Git will be able to deal with it. Let’s try again renaming the file, this time with Unix <code>mv</code>. First, we need to recreate the <code>krypton.txt</code> file:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">echo</span> <span class="st">&quot;Superman&#39;s home planet&quot;</span> <span class="kw">&gt;</span> krypton.txt
-$ <span class="kw">git</span> add krypton.txt
-$ <span class="kw">git</span> commit -m <span class="st">&#39;Adding planet Krypton again.&#39;</span></code></pre>
-<p>Let us rename the file and see what Git can figured out by itself:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">mv</span> krypton.txt earth.txt
-$ <span class="kw">git</span> status</code></pre>
-<pre class="output"><code>On branch master
-Changes not staged for commit:
-  (use &quot;git add/rm &lt;file&gt;...&quot; to update what will be committed)
-  (use &quot;git checkout -- &lt;file&gt;...&quot; to discard changes in working directory)
-
-        deleted:    krypton.txt
-
-Untracked files:
-  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
-
-    earth.txt
-
-no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)</code></pre>
-<p>Git has noticed that the file <code>krypton.txt</code> has disappeared from the file system and a new file <code>earth.txt</code> has showed up.</p>
-<p>Add those changes to the staging area:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add krypton.txt earth.txt
-$ <span class="kw">git</span> status</code></pre>
-<pre class="output"><code>On branch master
-Changes to be committed:
-  (use &quot;git reset HEAD &lt;file&gt;...&quot; to unstage)
-
-    renamed:    krypton.txt -&gt; earth.txt
-</code></pre>
-<p>Notice how Git has now figure out that the <code>krypton.txt</code> has not disappeared it has simply been renamed.</p>
-<p>The final step, as before, is to commit our change to the repository:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&#39;Superman&#39;</span>s home is Earth, told you before.<span class="st">&#39;</span></code></pre>
         </div>
       </div>
       </article>

--- a/discussion.html
+++ b/discussion.html
@@ -63,7 +63,7 @@ $ <span class="kw">git</span> config --global --unset log.abbrevCommit
 $ <span class="kw">git</span> config --global --unset format.pretty</code></pre>
 <aside class="callout panel panel-info">
 <div class="panel-heading">
-<h2><span class="glyphicon glyphicon-pushpin"></span>Version Controlling Your Git Configuration</h2>
+<h2><span class="glyphicon glyphicon-pushpin"></span>Undoing Git Configuration Changes</h2>
 </div>
 <div class="panel-body">
 <p>You can use the <code>--unset</code> flag to delete unwanted options from <code>.gitconfig</code>. Another way to roll back changes is to store your <code>.gitconfig</code> using Git.</p>
@@ -109,6 +109,107 @@ index df0654a..315bf3a 100644
 <p>An uninformative <code>git diff</code> is not the only consequence of using Git on binary files. However, most of the other problems boil down to whether or not a good diff is possible.</p>
 <p>This isn’t to say you should <em>never</em> use Git on binary files. A rule of thumb is that it’s okay if the binary file won’t change very often, and if it does change, you don’t care about merging in small differences between versions.</p>
 <p>We’ve already seen how a word processed report will fail this test. An example that passes the test is a logo for your organization or project. Even though a logo will be stored in a binary format such as <code>jpg</code> or <code>png</code>, you can expect it will remain fairly static through the lifetime of your repository. On the rare occasion that branding does change, you will probably just want to replace the logo completely rather than merge little differences in.</p>
+<h2 id="removing-a-file">Removing a file</h2>
+<p>Adding and modifying files are not the only actions one might take when working on a project. It might be required to remove a file from the repository.</p>
+<p>Create a new file for the planet Nibiru:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">echo</span> <span class="st">&quot;This is another name for fake planet X&quot;</span> <span class="kw">&gt;</span> nibiru.txt</code></pre>
+<p>Now add to the repository like you have learned earlier:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add nibiru.txt
+$ <span class="kw">git</span> commit -m <span class="st">&#39;adding info on nibiru&#39;</span>
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code>On branch master
+nothing to commit, working directory clean</code></pre>
+<p>Nibiru is not a real planet. That was a silly idea. Let us remove it from the disk and let Git know about it:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> rm nibiru.txt
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code>On branch master
+Changes to be committed:
+   (use &quot;git reset HEAD &lt;file&gt;...&quot; to unstage)
+
+   deleted:    nibiru.txt
+</code></pre>
+<p>The change has been staged. Now commit the removal, and remove the file from the repository itself. Note that the file will be removed in the new commit. The previous commit will still have the file, if you were to retrieve that specific commit.</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&#39;Removing info on Nibiru.  It is not a real planet!&#39;</span></code></pre>
+<h2 id="removing-a-file-with-unix">Removing a File with Unix</h2>
+<p>Sometimes we migth forget to remove the file through Git. If you removed the file with Unix <code>rm</code> instead of using <code>git rm</code>, no worries, Git is smart enough to notice the missing file. Let us recreate the file and commit it again.</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">echo</span> <span class="st">&quot;This is another name for fake planet X&quot;</span> <span class="kw">&gt;</span> nibiru.txt
+$ <span class="kw">git</span> add nibiru.txt
+$ <span class="kw">git</span> commit -m <span class="st">&#39;adding nibiru again&#39;</span></code></pre>
+<p>Now we remove the file with Unix <code>rm</code>:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">rm</span> nibiru.txt
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code>On branch master
+Changes not staged for commit:
+   (use &quot;git add/rm &lt;file&gt;...&quot; to update what will be committed)
+   (use &quot;git checkout -- &lt;file&gt;...&quot; to discard changes in working directory)
+
+    deleted:    nibiru.txt
+
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)</code></pre>
+<p>See how Git has noticed that the file <code>nibiru.txt</code> has been removed from the disk. The next step is to “stage” the removal of the file from the repository. This is done with the command <code>git rm</code> just as before.</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> rm nibiru.txt
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code>On branch master
+Changes to be committed:
+   (use &quot;git reset HEAD &lt;file&gt;...&quot; to unstage)
+
+   deleted:    nibiru.txt
+</code></pre>
+<p>The change that was made in Unix has now been staged and needs to be committed.</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&#39;Removing info on Nibiru, again!&#39;</span></code></pre>
+<h2 id="renaming-a-file">Renaming a File</h2>
+<p>Another common change when working on a project is to rename a file.</p>
+<p>Create a file for the planet Krypton:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">echo</span> <span class="st">&quot;Superman&#39;s home planet&quot;</span> <span class="kw">&gt;</span> krypton.txt</code></pre>
+<p>Add it to the repository:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add krypton.txt
+$ <span class="kw">git</span> commit -m <span class="st">&#39;Adding planet Krypton&#39;</span></code></pre>
+<p>We all know that Superman moved to Earth. Not that he had much choice. Now his home planet is Earth.</p>
+<p>Rename the file <code>krypton.txt</code> to <code>earth.txt</code> with Git:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> mv krypton.txt earth.txt
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+# Changes to be committed:
+#   (use &quot;git reset HEAD &lt;file&gt;...&quot; to unstage)
+#
+#   renamed:    krypton.txt -&gt; earth.txt
+#</code></pre>
+<p>The final step is commit our change to the repository:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&#39;Superman&#39;</span>s home is now Earth<span class="st">&#39;</span></code></pre>
+<h2 id="renaming-a-file-with-unix">Renaming a File with Unix</h2>
+<p>If you forgot to use Git and you used Unix <code>mv</code> instead of <code>git mv</code>, you will have a touch more work to do but Git will be able to deal with it. Let’s try again renaming the file, this time with Unix <code>mv</code>. First, we need to recreate the <code>krypton.txt</code> file:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">echo</span> <span class="st">&quot;Superman&#39;s home planet&quot;</span> <span class="kw">&gt;</span> krypton.txt
+$ <span class="kw">git</span> add krypton.txt
+$ <span class="kw">git</span> commit -m <span class="st">&#39;Adding planet Krypton again.&#39;</span></code></pre>
+<p>Let us rename the file and see what Git can figured out by itself:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">mv</span> krypton.txt earth.txt
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code>On branch master
+Changes not staged for commit:
+  (use &quot;git add/rm &lt;file&gt;...&quot; to update what will be committed)
+  (use &quot;git checkout -- &lt;file&gt;...&quot; to discard changes in working directory)
+
+        deleted:    krypton.txt
+
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+
+    earth.txt
+
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)</code></pre>
+<p>Git has noticed that the file <code>krypton.txt</code> has disappeared from the file system and a new file <code>earth.txt</code> has showed up.</p>
+<p>Add those changes to the staging area:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add krypton.txt earth.txt
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code>On branch master
+Changes to be committed:
+  (use &quot;git reset HEAD &lt;file&gt;...&quot; to unstage)
+
+    renamed:    krypton.txt -&gt; earth.txt
+</code></pre>
+<p>Notice how Git has now figure out that the <code>krypton.txt</code> has not disappeared it has simply been renamed.</p>
+<p>The final step, as before, is to commit our change to the repository:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&#39;Superman&#39;</span>s home is Earth, told you before.<span class="st">&#39;</span></code></pre>
         </div>
       </div>
       </article>

--- a/discussion.md
+++ b/discussion.md
@@ -251,7 +251,7 @@ $ git commit -m 'Removing info on Nibiru.  It is not a real planet!'
 ~~~
 
 
-#### Removing with Unix
+## Removing with Unix
 Sometimes we migth forget to remove the file through Git. If you removed the 
 file with Unix `rm` instead of using `git rm`, no worries,
 Git is smart enough to notice the missing file. Let us recreate the file and

--- a/discussion.md
+++ b/discussion.md
@@ -91,7 +91,7 @@ $ git config --global --unset log.abbrevCommit
 $ git config --global --unset format.pretty
 ~~~
 
-> ## Version Controlling Your Git Configuration {.callout}
+> ## Undoing Git Configuration Changes {.callout}
 > 
 > You can use the `--unset` flag to delete unwanted options from `.gitconfig`.
 > Another way to roll back changes is to store your `.gitconfig` using Git.
@@ -251,7 +251,7 @@ $ git commit -m 'Removing info on Nibiru.  It is not a real planet!'
 ~~~
 
 
-## Removing with Unix
+## Removing a File with Unix
 Sometimes we migth forget to remove the file through Git. If you removed the 
 file with Unix `rm` instead of using `git rm`, no worries,
 Git is smart enough to notice the missing file. Let us recreate the file and
@@ -347,7 +347,7 @@ $ git commit -m 'Superman's home is now Earth'
 ~~~
 
 
-## Renaming with Unix
+## Renaming a File with Unix
 If you forgot to use Git and you used Unix `mv` instead 
 of `git mv`, you will have a touch more work to do but Git will 
 be able to deal with it. Let's try again renaming the file, 

--- a/discussion.md
+++ b/discussion.md
@@ -347,7 +347,7 @@ $ git commit -m 'Superman's home is now Earth'
 ~~~
 
 
-#### Renaming with Unix
+## Renaming with Unix
 If you forgot to use Git and you used Unix `mv` instead 
 of `git mv`, you will have a touch more work to do but Git will 
 be able to deal with it. Let's try again renaming the file, 


### PR DESCRIPTION
After cloning the git-novice repository, "make check" returned errors, i.e.,

    python tools/check.py .
    ERROR: In ./discussion.md: Heading at line 254 should be level 2
    ERROR: In ./discussion.md: Heading at line 350 should be level 2
    ERROR: In ./discussion.md: Found callout box with unrecognized style 'callout'
    WARNING: 3 errors were encountered during validation. See log for details.
    Makefile:38: recipe for target 'check' failed
    make: *** [check] Error 3

The first two were fixed and the third appears to be a bug with "make check" itself so it was left as-is. The title for the callout box was edited to be correct for its content and the two other headings were edited to clearly say files are being manipulated.
