### PR TITLE
Added definition and link for DOI

### DIFF
--- a/10-open.md
+++ b/10-open.md
@@ -45,7 +45,9 @@ the process looks like this:
 *   The data that the scientist collects is stored in an open access repository
     like [figshare](http://figshare.com/) or
     [Zenodo](http://zenodo.org), possibly as soon as it's collected,
-    and given its own DOI. Or the data was already published and is stored in
+    and given its own 
+    [Digital Object Identifier](https://en.wikipedia.org/wiki/Digital_object_identifier) (DOI).
+    Or the data was already published and is stored in
     [Dryad](http://datadryad.org/).
 *   The scientist creates a new repository on GitHub to hold her work.
 *   As she does her analysis,


### PR DESCRIPTION
I am adding the expansion of Digital Object Identifier earlier in the document. It seems to be just thrown out there and if learners are not familiar with the term and they not look towards the bottom of the page, there may be some confusion. I also made the expansion as a link to the wikipedia page. 