### PR TITLE
reference: Replace 'revision' with 'commit'

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -17,14 +17,14 @@ subtitle: Reference
 *   `git status` shows the status of a repository.
 *   Files can be stored in a project's working directory (which users see),
     the staging area (where the next commit is being built up)
-    and the local repository (where revisions are permanently recorded).
+    and the local repository (where commits are permanently recorded).
 *   `git add` puts files in the staging area.
-*   `git commit` saves the revisions in the staging area to the local repository.
+*   `git commit` saves the staged content as a new commit in the local repository.
 *   Always write a log message when committing changes.
 
 ## [Exploring History](05-history.html)
 
-*   `git diff` displays differences between revisions.
+*   `git diff` displays differences between commits.
 *   `git checkout` recovers old versions of files.
 
 ## [Ignoring Things](06-ignore.html)

--- a/reference.md
+++ b/reference.md
@@ -125,8 +125,7 @@ resolve
     being managed by a [version control](#version-control) system.
 
 revision
-:   A recorded [change set](#change-set) of a [version control](#version-control) 
-    [repository](#repository). The same as a [commit](#commit).
+:   A synonym for [commit](#commit).
 
 SHA-1
 :   [SHA-1 hashes](http://en.wikipedia.org/wiki/SHA-1) is what Git uses to compute identifiers, including for commits.

--- a/reference.md
+++ b/reference.md
@@ -80,7 +80,7 @@ change set
     [repository](#repository).
 
 commit
-:   To record the current state of a set of files (a [change set](#changeset))
+:   To record the current state of a set of files (a [change set](#change-set))
     in a [version control](#version-control) [repository](#repository). As a noun, 
     the result of commiting, i.e. a recorded change set in a repository.
     If a commit contains changes to multiple files,


### PR DESCRIPTION
Fixing a few instances missed by #139, based on the consensus formed
in #133.  More details on these changes (and some drive-by stuff I
noticed while making them) in the commit messages.