### PR TITLE
Add exercise to explore commonly used licenses

### DIFF
--- a/11-licensing.md
+++ b/11-licensing.md
@@ -143,3 +143,15 @@ Greg Wilson: "Software Carpentry: Lessons Learned". arXiv:1307.5448, July 2013.
 > Can you do this unilaterally,
 > or do you need permission from someone in your institution?
 > If so, who?
+
+> ## What licenses have I already accepted? {.challenge}
+>
+> Many of the software tools we use on a daily basis (including in this workshop) are
+> released as open-source software. Pick a project on GitHub from the list below, or
+> one of your own choosing. Find its license (usually in a file called `LICENSE` or 
+> `COPYING`) and talk about how it restricts your use of the software. Is it one of
+> the licenses discussed in this session? How is it different?
+> - [Git](https://github.com/git/git), the source-code management tool
+> - [CPython](https://github.com/python/cpython), the standard implementation of the Python language
+> - [Jupyter](https://github.com/jupyter), the project behind the web-based Python notebooks we'll be using
+> - [EtherPad](https://github.com/ether/etherpad-lite), a real-time collaborative editor


### PR DESCRIPTION
This exercise is designed to encourage the learners to be more aware of the sorts of software licenses they have already accepted. Even amongst the tools used in the Software Carpentry workshops, there are several different licenses used. Students may discuss with others and/or contribute to a list in the EtherPad.