### PR TITLE
Add challenge to check understanding of push vs. commit

### DIFF
--- a/07-github.md
+++ b/07-github.md
@@ -187,3 +187,8 @@ this command would download them to our local repository.
 > Make changes to your local repository and push these changes.
 > Go to the repo you just created on Github and check the [timestamps](reference.html#timestamp) of the files.
 > How does GitHub record times, and why?
+
+> ## Push vs. commit {.challenge}
+>
+> In this lesson, we introduced the "git push" command.
+> How is "git push" different from "git commit"?


### PR DESCRIPTION
Add a challenge in the github lesson to check understanding of push vs. commit.

The "07 github" lesson is the first time the "push" command is introduced. It seems like a useful moment for students to take to reflect on the difference between "push" (which they just learned) and "commit" (which they already knew), since both might just sound like "save my work" to an unfamiliar learner.