### PR TITLE
Added two references to cheatsheets

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -3,6 +3,11 @@ layout: page
 title: Version Control with Git
 subtitle: Reference
 ---
+## Git Cheatsheets for Quick Reference 
+* A great [printable git cheatsheet](https://training.github.com/kit/downloads/github-git-cheat-sheet.pdf) is available in PDF from the GitHub training website.
+* An [interactive one-page visualisation](http://ndpsoftware.com/git-cheatsheet.html) about the relationships between workspace, staging area, local repository, upstream repository, and the commands associated with each (with explanations).
+* Both resources are also available in other languages e.g. Spanish, French, and more
+
 ## [Setting Up Git](02-setup.html)
 
 *   Use `git config` to configure


### PR DESCRIPTION
This might be useful to refer students to at the beginning of a lesson or even to print out (at least the PDF document) and hand out to students before a workshop.  The interactive document may be confusing as it uses terminology like "index" in stead of "staging area" but it does explain so in the description when hovering over.