### PR TITLE
Add challenge to 05-history.md

### DIFF
--- a/05-history.md
+++ b/05-history.md
@@ -289,20 +289,20 @@ Jennifer is collaborating on her python script with her colleagues and realises 
 
 > ## Checking Understanding of git diff {.challenge}
 >
-> Consider this command: `git diff HEAD~3 mars.txt`. What do you predict this command 
-> will do if you execute it? What happens when you do execute it? Why? 
+> Consider this command: `git diff HEAD~3 mars.txt`. What do you predict this command
+> will do if you execute it? What happens when you do execute it? Why?
 >
-> Try another command, `git diff [ID] mars.txt`, where [ID] is replaced with 
-> the unique identifier for your most recent commit. What do you think will happen, 
-> and what does happen? 
+> Try another command, `git diff [ID] mars.txt`, where [ID] is replaced with
+> the unique identifier for your most recent commit. What do you think will happen,
+> and what does happen?
 
 
 > ## Getting Rid of Staged Changes {.challenge}
 >
 > `git checkout` can be used to restore a previous commit when unstaged changes have
-> been made, but will it also work for changes that have been staged but not committed? 
-> Make a change to `mars.txt`, add that change, and use `git checkout` to see if 
-> you can remove your change. 
+> been made, but will it also work for changes that have been staged but not committed?
+> Make a change to `mars.txt`, add that change, and use `git checkout` to see if
+> you can remove your change.
 
 
 
@@ -314,8 +314,7 @@ Jennifer is collaborating on her python script with her colleagues and realises 
 > the right commit ID, especially if the commit is from several months ago.
 >
 > Imaging the `planets` project has more than 50 files.
-> You would like to find a specific commit which a very large section of text
-> in `mars.txt` is modified.
+> You would like to find a commit with specific text in `mars.txt` is modified.
 > When you type `git log`, a very long list appeared,
 > How can you narrow down the search?
 >
@@ -327,34 +326,21 @@ Jennifer is collaborating on her python script with her colleagues and realises 
 > ~~~
 >
 > Unfortunately some of these commit messages are very ambiguous e.g. `update files`.
-> How can you narrow down further?
+> How can you search through these files?
 >
-> Recorded the `git commit` you performed earlier,
-> git will display a summary message like this `1 file changed, 1 insertion(+)`.
-> Is that possible to display some information like these? Let's try the following:
->
-> ~~~ {.bash}
-> $ git log --stat mars.txt
-> ~~~
->
-> You might find something like this.
-> At this particular commit, you added 23 lines and deleted 67 lines to mars.txt
->
-> ~~~ {.output}
-> mars.txt | 90 +++++++++++++++++++++++-------------------------------------------------------------------
-> 1 file changed, 23 insertions(+), 67 deletions(-)
-> ~~~
->
-> This switch `--stat` can apply to `git diff` as well. Try the following
->
-> ~~~  {.bash}
-> $ git diff --stat
-> ~~~
->
-> What does the following command do?
+> Both `git diff` and `git log` are very useful and they summarize different part of the history for you.
+> Is that possible to combine both? Let's try the following:
 >
 > ~~~ {.bash}
-> $ git diff --stat HEAD~3 HEAD~1 *.txt
+> $ git log --patch mars.txt
+> ~~~
+>
+> You should get a long list of output, and you should be able to see both commit messages and the difference between each commit.
+>
+> Question: What does the following command do?
+>
+> ~~~ {.bash}
+> $ git log --patch HEAD~3 HEAD~1 *.txt
 > ~~~
 >
 >

--- a/05-history.md
+++ b/05-history.md
@@ -212,22 +212,22 @@ moving backward and forward in time becomes much easier.
 > let her recover the last committed version of her Python script called
 > `data_cruncher.py`?
 >
-> 1. 
+> 1.
 >
 >     ~~~
 >     $ git checkout HEAD
 >     ~~~
-> 2. 
+> 2.
 >
 >     ~~~
 >     $ git checkout HEAD data_cruncher.py
 >     ~~~
-> 3. 
+> 3.
 >
 >     ~~~
 >     $ git checkout HEAD~1 data_cruncher.py
 >     ~~~
-> 4. 
+> 4.
 >
 >     ~~~
 >     $ git checkout <unique ID of last commit> data_cruncher.py
@@ -249,28 +249,83 @@ moving backward and forward in time becomes much easier.
 > $ cat venus.txt #this will print the contents of venus.txt to the screen
 > ~~~
 >
-> 1. 
-> 
+> 1.
+>
 >     ~~~ {.output}
 >     Venus is too hot to be suitable as a base
 >     ~~~
 >
-> 2. 
-> 
+> 2.
+>
 >     ~~~ {.output}
 >     Venus is beautiful and full of love
 >     ~~~
 >
-> 3. 
-> 
+> 3.
+>
 >     ~~~ {.output}
 >     Venus is beautiful and full of love
 >     Venus is too hot to be suitable as a base
 >     ~~~
 >
-> 4. 
-> 
+> 4.
+>
 >     ~~~ {.output}
 >     Error because you have changed venus.txt without committing the changes
 >     ~~~
 
+
+
+
+
+> ## Explore and summarize histories {.challenge}
+>
+> Exploring history is an important part of git, often it is a challenge to find
+> the right commit ID, especially if the commit is from several months ago.
+>
+> Imaging the `planets` project has more than 50 files.
+> You would like to find a specific commit which a very large section of text
+> in `mars.txt` is modified.
+> When you type `git log`, a very long list appeared,
+> How can you narrow down the search?
+>
+> Recorded that the `git diff` command allow us to explore one specific file,
+> e.g. `git diff mars.txt`. We can apply the similar idea here.
+>
+> ~~~ {.bash}
+> $ git log mars.txt
+> ~~~
+>
+> Unfortunately some of these commit messages are very ambiguous e.g. `update files`.
+> How can you narrow down further?
+>
+> Recorded the `git commit` you performed earlier,
+> git will display a summary message like this `1 file changed, 1 insertion(+)`.
+> Is that possible to display some information like these? Let's try the following:
+>
+> ~~~ {.bash}
+> $ git log --stat mars.txt
+> ~~~
+>
+> You might find something like this.
+> At this particular commit, you added 23 lines and deleted 67 lines to mars.txt
+>
+> ~~~ {.output}
+> mars.txt | 90 +++++++++++++++++++++++-------------------------------------------------------------------
+> 1 file changed, 23 insertions(+), 67 deletions(-)
+> ~~~
+>
+> This switch `--stat` can apply to `git diff` as well. Try the following
+>
+> ~~~  {.bash}
+> $ git diff --stat
+> ~~~
+>
+> What does the following command do?
+>
+> ~~~ {.bash}
+> $ git diff --stat HEAD~3 HEAD~1 *.txt
+> ~~~
+>
+>
+>


### PR DESCRIPTION
This is part of the requirements for SWC trainer session.
`git log <filename>` was not mentioned in `04-changes.md`.
Since both `git diff --staged` and `git diff commitID filename` are used previously.
This should be not be a big leap to introduce `git log --switch commitID filename`