### PR TITLE
Hotfix - fix incorrect subscript in challenges

### DIFF
--- a/06-ignore.md
+++ b/06-ignore.md
@@ -123,7 +123,8 @@ nothing to commit, working directory clean
 > ## Ignoring nested files {.challenge}
 >
 > Given a directory structure that looks like:
-> ~~~
+>
+> ~~~ {.bash}
 > results/data
 > results/plots
 > ~~~
@@ -139,7 +140,8 @@ nothing to commit, working directory clean
 > ## Ignoring files deep in a directory {.challenge}
 >
 > Given a directory structure that looks like:
-> ~~~
+>
+> ~~~ {.bash}
 > results/data/position/gps/useless.data
 > results/plots
 > ~~~
@@ -151,7 +153,8 @@ nothing to commit, working directory clean
 > ## The order of rules {.challenge}
 >
 > Given a `.gitignore` file with the following contents:
-> ~~~
+>
+> ~~~ {.bash}
 > *.data
 > !*.data
 > ~~~


### PR DESCRIPTION
There are three challenges where the some texts are shown in subscript and smaller font
Looks like

`Given a directory structure that looks like:` <sub>results/data results/plots</sub>

The fix placed these in a box, but can be quote as well.