### PR TITLE
Removes reference to push -u, and intermediate git lesson (fixes #184)

### DIFF
--- a/07-github.html
+++ b/07-github.html
@@ -35,7 +35,6 @@
 <div class="panel-body">
 <ul>
 <li>Explain what remote repositories are and why they are useful.</li>
-<li>Clone a remote repository.</li>
 <li>Push to or pull from a remote repository.</li>
 </ul>
 </div>
@@ -79,7 +78,7 @@ $ <span class="kw">git</span> init</code></pre>
 <img src="fig/github-change-repo-string.png" alt="Changing the Repository URL on GitHub" /><p class="caption">Changing the Repository URL on GitHub</p>
 </div>
 <p>Copy that URL from the browser, go into the local <code>planets</code> repository, and run this command:</p>
-<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> remote add origin https://github.com/vlad/planets</code></pre>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> remote add origin https://github.com/vlad/planets.git</code></pre>
 <p>Make sure to use the URL for your repository rather than Vlad’s: the only difference should be your username instead of <code>vlad</code>.</p>
 <p>We can check that the command has worked by running <code>git remote -v</code>:</p>
 <pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> remote -v</code></pre>
@@ -114,23 +113,16 @@ $ <span class="kw">git</span> config --global --unset https.proxy</code></pre>
 <h2><span class="glyphicon glyphicon-pushpin"></span>Password Managers</h2>
 </div>
 <div class="panel-body">
-<p>If your operating system has a password manager configured, <code>git push</code> will try to use it when it needs your username and password. If you want to type your username and password at the terminal instead of using a password manager, type:</p>
+<p>If your operating system has a password manager configured, <code>git push</code> will try to use it when it needs your username and password. For example, this is the default behavior for Git Bash on Windows. If you want to type your username and password at the terminal instead of using a password manager, type:</p>
 <pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">unset</span> <span class="ot">SSH_ASKPASS</span></code></pre>
-<p>You may want to add this command at the end of your <code>~/.bashrc</code> to make it the default behavior.</p>
+<p>in the terminal, before you run <code>git push</code>. Despite the name, <a href="http://git-scm.com/docs/gitcredentials#_requesting_credentials">git uses <code>SSH_ASKPASS</code> for all credential entry</a>, so you may want to unset <code>SSH_ASKPASS</code> whether you are using git via SSH or https.</p>
+<p>You may also want to add <code>unset SSH_ASKPASS</code> at the end of your <code>~/.bashrc</code> to make git default to using the terminal for usernames and passwords.</p>
 </div>
 </aside>
 <p>Our local and remote repositories are now in this state:</p>
 <div class="figure">
 <img src="fig/github-repo-after-first-push.svg" alt="GitHub Repository After First Push" /><p class="caption">GitHub Repository After First Push</p>
 </div>
-<aside class="callout panel panel-info">
-<div class="panel-heading">
-<h2><span class="glyphicon glyphicon-pushpin"></span>The ‘-u’ Flag</h2>
-</div>
-<div class="panel-body">
-<p>You may see a <code>-u</code> option used with <code>git push</code> in some documentation. It is related to concepts we cover in our intermediate lesson, and can safely be ignored for now.</p>
-</div>
-</aside>
 <p>We can pull changes from the remote repository to the local one as well:</p>
 <pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> pull origin master</code></pre>
 <pre class="output"><code>From https://github.com/vlad/planets
@@ -139,10 +131,36 @@ Already up-to-date.</code></pre>
 <p>Pulling has no effect in this case because the two repositories are already synchronized. If someone else had pushed some changes to the repository on GitHub, though, this command would download them to our local repository.</p>
 <section class="challenge panel panel-success">
 <div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>GitHub GUI</h2>
+</div>
+<div class="panel-body">
+<p>Browse to your <code>planets</code> repository on GitHub. Under the Code tab, find and click on the text that says “XX commits” (where “XX” is some number). Hover over, and click on, the three buttons to the right of each commit. What information can you gather/explore from these buttons? How would you get that same information in the shell?</p>
+</div>
+</section>
+<section class="challenge panel panel-success">
+<div class="panel-heading">
 <h2><span class="glyphicon glyphicon-pencil"></span>GitHub Timestamp</h2>
 </div>
 <div class="panel-body">
-<p>Create a repository on GitHub, clone it, add a file, push those changes to GitHub, and then look at the <a href="reference.html#timestamp">timestamp</a> of the change on GitHub. How does GitHub record times, and why?</p>
+<p>Create a remote repository on GitHub. Push the contents of your local repository to the remote. Make changes to your local repository and push these changes. Go to the repo you just created on Github and check the <a href="reference.html#timestamp">timestamps</a> of the files. How does GitHub record times, and why?</p>
+</div>
+</section>
+<section class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Push vs. commit</h2>
+</div>
+<div class="panel-body">
+<p>In this lesson, we introduced the “git push” command. How is “git push” different from “git commit”?</p>
+</div>
+</section>
+<section class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Fixing up remote settings</h2>
+</div>
+<div class="panel-body">
+<p>It happens quite often in practice that you made a typo in the remote URL. This exercice is about how to fix this kind of issues. First start by adding a remote with an invalid URL:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">git</span> remote add broken https://github.com/this/url/is/invalid</code></pre>
+<p>Do you get an error when adding the remote? Can you think of a command that would make it obvious that your remote URL was not valid? Can you figure out how to fix the URL (tip: use <code>git remote -h</code>)? Don’t forget to clean up and remove this remote once you are done with this exercise.</p>
 </div>
 </section>
         </div>
@@ -158,5 +176,6 @@ Already up-to-date.</code></pre>
     <!-- Javascript placed at the end of the document so the pages load faster -->
     <script src="http://software-carpentry.org/v5/js/jquery-1.9.1.min.js"></script>
     <script src="css/bootstrap/bootstrap-js/bootstrap.js"></script>
+    <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/07-github.md
+++ b/07-github.md
@@ -163,12 +163,6 @@ Our local and remote repositories are now in this state:
 
 ![GitHub Repository After First Push](fig/github-repo-after-first-push.svg)
 
-> ## The '-u' Flag {.callout}
->
-> You may see a `-u` option used with `git push` in some documentation.
-> It is related to concepts we cover in our intermediate lesson,
-> and can safely be ignored for now.
-
 We can pull changes from the remote repository to the local one as well:
 
 ~~~ {.bash}


### PR DESCRIPTION
Fixes #184.
The -u flag isn't explained, other than to ask the user to ignore it.
It makes more sense not to mention it at all - it only adds confusion.

The referenced intermediate lesson isn't linked to, and until it is a
lesson on the Software Carpentry page, it only adds further confusion.

Markdown file changed, and page 7 rebuilt.