### PR TITLE
add challenge for staging multiple files

### DIFF
--- a/04-changes.md
+++ b/04-changes.md
@@ -453,6 +453,18 @@ repository (`git commit`):
 >     $ git commit -m myfile.txt "my recent changes"
 >     ~~~
 
+> ## Committing Multiple Files {.challenge}
+>
+> The staging area can hold changes from any number of files
+> that you want to commit as a single snapshot.
+>
+> 1. Add some text to `mars.txt` noting your decision
+> to consider Venus as a base
+> 2. Create a new file `venus.txt` with your initial thoughts
+> about Venus as a base for you and your friends
+> 3. Add changes from both files to the staging area,
+> and commit those changes.
+
 > ## `bio` Repository {.challenge}
 >
 > Create a new Git repository on your computer called `bio`.


### PR DESCRIPTION
_((note, this PR is for my licensed-instructor checkout procedure))_

Purpose of exercise: lead student through the use-case where multiple files are added to the staging area before a commit is done.

The graphic images show multiple files going into the staging area, but there is no exercise encouraging the user to do so. 

