### PR TITLE
Refactor 05-history

### DIFF
--- a/05-history.md
+++ b/05-history.md
@@ -53,7 +53,7 @@ We will need to manufacture our own oxygen
 ~~~
 
 `git status` now tells us that the file has been changed,
-but those changes haven't been staged:
+but those changes haven't been staged to be committed:
 
 ~~~ {.bash}
 $ git status

--- a/05-history.md
+++ b/05-history.md
@@ -1,102 +1,48 @@
 ---
 layout: page
 title: Version Control with Git
-subtitle: Exploring History
+subtitle: Exploring History and Undoing Mistakes
 minutes: 25
 ---
 > ## Learning Objectives {.objectives}
 >
-> *   Identify and use Git commit numbers.
-> *   Compare various versions of tracked files.
+> *   Identify commits by their Git commit numbers.
 > *   Restore old versions of files.
+> *   Identify commits by how many commits have happened since.
+> *   Compare different versions of tracked files.
 
-If we want to see what we changed at different steps, we can use `git diff`
-again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to old
-commits:
-
-~~~ {.bash}
-$ git diff HEAD~1 mars.txt
-~~~
-~~~ {.output}
-diff --git a/mars.txt b/mars.txt
-index 315bf3a..b36abfd 100644
---- a/mars.txt
-+++ b/mars.txt
-@@ -1,2 +1,3 @@
- Cold and dry, but everything is my favorite color
- The two moons may be a problem for Wolfman
-+But the Mummy will appreciate the lack of humidity
-~~~
-~~~ {.bash}
-$ git diff HEAD~2 mars.txt
-~~~
-~~~ {.output}
-diff --git a/mars.txt b/mars.txt
-index df0654a..b36abfd 100644
---- a/mars.txt
-+++ b/mars.txt
-@@ -1 +1,3 @@
- Cold and dry, but everything is my favorite color
-+The two moons may be a problem for Wolfman
-+But the Mummy will appreciate the lack of humidity
-~~~
-
-In this way,
-we can build up a chain of commits.
-The most recent end of the chain is referred to as `HEAD`;
-we can refer to previous commits using the `~` notation,
-so `HEAD~1` (pronounced "head minus one")
-means "the previous commit",
-while `HEAD~123` goes back 123 commits from where we are now.
-
-We can also refer to commits using
-those long strings of digits and letters
-that `git log` displays.
-These are unique IDs for the changes,
-and "unique" really does mean unique:
-every change to any set of files on any computer
-has a unique 40-character identifier.
-Our first commit was given the ID
-f22b25e3233b4645dabd0d81e651fe074bd8e73b,
-so let's try this:
+Recall that `git log` shows us the history of our project by listing the
+commits we have made, their dates, and their commit messages:
 
 ~~~ {.bash}
-$ git diff f22b25e3233b4645dabd0d81e651fe074bd8e73b mars.txt
+$ git log
 ~~~
 ~~~ {.output}
-diff --git a/mars.txt b/mars.txt
-index df0654a..b36abfd 100644
---- a/mars.txt
-+++ b/mars.txt
-@@ -1 +1,3 @@
- Cold and dry, but everything is my favorite color
-+The two moons may be a problem for Wolfman
-+But the Mummy will appreciate the lack of humidity
+commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
+Author: Vlad Dracula <vlad@tran.sylvan.ia>
+Date:   Thu Aug 22 10:14:07 2013 -0400
+
+    Discuss concerns about Mars' climate for Mummy
+
+commit 34961b159c27df3b475cfe4415d94a6d1fcd064d
+Author: Vlad Dracula <vlad@tran.sylvan.ia>
+Date:   Thu Aug 22 10:07:21 2013 -0400
+
+    Add concerns about effects of Mars' moons on Wolfman
+
+commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
+Author: Vlad Dracula <vlad@tran.sylvan.ia>
+Date:   Thu Aug 22 09:51:46 2013 -0400
+
+    Start notes on Mars as a base
 ~~~
 
-That's the right answer,
-but typing out random 40-character strings is annoying,
-so Git lets us use just the first few characters:
+Because git keeps track of not only the current state of our files but
+also their entire history, we can restore any file (or even the entire
+project) to any place in its history. This is very useful if we make a mistake
+and want to undo it!
 
-~~~ {.bash}
-$ git diff f22b25e mars.txt
-~~~
-~~~ {.output}
-diff --git a/mars.txt b/mars.txt
-index df0654a..b36abfd 100644
---- a/mars.txt
-+++ b/mars.txt
-@@ -1 +1,3 @@
- Cold and dry, but everything is my favorite color
-+The two moons may be a problem for Wolfman
-+But the Mummy will appreciate the lack of humidity
-~~~
-
-
-All right! So
-we can save changes to files and see what we've changed&mdash;now how
-can we restore older versions of things?
-Let's suppose we accidentally overwrite our file:
+For example, let's suppose we accidentally overwrite our file:
 
 ~~~ {.bash}
 $ nano mars.txt
@@ -123,9 +69,64 @@ $ git status
 no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
 
-We can put things back the way they were
-by using `git checkout`:
+Let's restore the version of `mars.txt` from the most recent commit.
+Each commit is uniquely identified by a long string of letters and digits;
+we can find a commit's identifier from its entry in `git log`.  Looking above,
+we see that our most recent commit has the identifier 
+`005937fbe2a98fb83f0ade869025dc2636b4dad5`.  We can ask for the version of
+`mars.txt` from that commit using `git checkout`:
 
+~~~ {.bash}
+$ git checkout 005937fbe2a98fb83f0ade869025dc2636b4dad5 mars.txt
+$ cat mars.txt
+~~~
+~~~ {.output}
+Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity
+~~~
+
+Ah, crisis averted -- Git is a lifesaver for anyone who has every accidentally
+deleted a file.
+
+Using `git checkout`, we can look at any commit in the history of the project.
+However, typing out random 40-character strings is annoying,
+so Git lets us use just the first few characters:
+
+~~~ {.bash}
+$ git checkout 34961b1 mars.txt
+$ cat mars.txt
+~~~
+~~~ {.output}
+Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+~~~
+
+> ## Don't lose your HEAD {.callout}
+> Above we used
+>
+> ~~~ {.bash}
+> $ git checkout 34961b1 mars.txt
+> ~~~
+>
+> to revert mars.txt to its state after the commit 34961b1.
+> If you forget `mars.txt` in that command, git will tell you that "You are in
+> 'detached HEAD' state." In this state, you shouldn't make any changes.
+> You can fix this by reattaching your head using ``git checkout master``
+
+Sometimes it's easier to refer to commits not by their commit ID but by how
+many commits ago they were.  The most recent commit is always called `HEAD`,
+the commit before that is called `HEAD~1` (pronounced "`HEAD` minus one"),
+the commit before *that* is `HEAD~2`, etc.  This makes it easy to recover
+from mistakes by going back to the most recent commit:
+
+~~~ {.bash}
+$ nano mars.txt
+$ cat mars.txt
+~~~
+~~~ {.output}
+We must take care not to disturb the native lifeforms!
+~~~
 ~~~ {.bash}
 $ git checkout HEAD mars.txt
 $ cat mars.txt
@@ -136,38 +137,44 @@ The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
 ~~~
 
-As you might guess from its name,
-`git checkout` checks out (i.e., restores) an old version of a file.
-In this case,
-we're telling Git that we want to recover the version of the file recorded in `HEAD`,
-which is the last saved commit.
-If we want to go back even further,
-we can use a commit identifier instead:
+> ## Choose the right commit {.callout}
+> If we're trying to undo a mistake that was made several commits ago,
+> a common mistake is to `git checkout` the commit in which that change
+> was made.  Remember to use the commit number that identifies the state
+> of the repository *before* the change we're trying to undo.
+
+Finally, if we want to see what changed since a particular commit, we can use
+`git diff` again.  For example, to see what has changed since the last commit:
 
 ~~~ {.bash}
-$ git checkout f22b25e mars.txt
+$ git diff HEAD~1 mars.txt
+~~~
+~~~ {.output}
+diff --git a/mars.txt b/mars.txt
+index 315bf3a..b36abfd 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1,2 +1,3 @@
+ Cold and dry, but everything is my favorite color
+ The two moons may be a problem for Wolfman
++But the Mummy will appreciate the lack of humidity
 ~~~
 
-> ## Don't lose your HEAD {.callout}
-> Above we used
->
-> ~~~ {.bash}
-> $ git checkout f22b25e mars.txt
-> ~~~
->
-> to revert mars.txt to its state after the commit f22b25e.
-> If you forget `mars.txt` in that command, git will tell you that "You are in
-> 'detached HEAD' state." In this state, you shouldn't make any changes.
-> You can fix this by reattaching your head using ``git checkout master``
+We can also refer to a commit by its commit identifier:
 
-
-It's important to remember that
-we must use the commit number that identifies the state of the repository
-*before* the change we're trying to undo.
-A common mistake is to use the number of
-the commit in which we made the change we're trying to get rid of.
-In the example below, we want to retrieve the state from before the most
-recent commit (`HEAD~1`), which is commit `f22b25e`:
+~~~ {.bash}
+$ git diff f22b25e mars.txt
+~~~
+~~~ {.output}
+diff --git a/mars.txt b/mars.txt
+index df0654a..b36abfd 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1 +1,3 @@
+ Cold and dry, but everything is my favorite color
++The two moons may be a problem for Wolfman
++But the Mummy will appreciate the lack of humidity
+~~~
 
 ![Git Checkout](fig/git-checkout.svg)
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Andrew Rohl <a.rohl@curtin.edu.au>
 Michael Sarahan <msarahan@gmail.com>
 Raniere Silva <raniere@ime.unicamp.br>
 Peter Steinbach <steinbach@scionics.de>
+Brian Teague <bpteague@gmail.com>
 Tiffany Timbers <tiffany.timbers@gmail.com>
 Danielle Traphagen <dtrapezoid@gmail.com>
 Belinda Weaver <b.weaver@uq.edu.au>

--- a/index.md
+++ b/index.md
@@ -59,7 +59,7 @@ to be shared can and should be stored in a version control system.
 2.  [Setting Up Git](02-setup.html)
 3.  [Creating a Repository](03-create.html)
 4.  [Tracking Changes](04-changes.html)
-5.  [Exploring History](05-history.html)
+5.  [Exploring History and Undoing Mistakes](05-history.html)
 6.  [Ignoring Things](06-ignore.html)
 7.  [Remotes in GitHub](07-github.html)
 8.  [Collaborating](08-collab.html)


### PR DESCRIPTION
This PR is in fulfillment of the new instructor checkout requirement.

I went to improve the learning objectives in 05-history and ended up refactoring the entire lesson.  The content is the same but the emphasis and order of presentation is different.  The lesson currently starts with `git diff` and teaches readers how to refer to commits using `HEAD~x` notation, but I found I didn't have any good context to attach those new facts to, and was left asking "so what?"

My refactoring moves the concept of "going back in time" to the very beginning, motivated with the same example used later on ("Oops I over-wrote a file").  It introduces commit IDs and `git checkout` pretty much simultaneously; then short IDs, `git diff` for looking at history, and `HEAD~x`.

I welcome comments and feedback!  Unfortunately the diff is so big that reading it is a PITA; I re-rendered the HTML and pushed it to my own repo.  You can see the new version at

http://bpteague.github.io/git-novice/05-history.html
