### PR TITLE
Add note about accepting XCode license on MacOSx

### DIFF
--- a/14-supplemental-rstudio.md
+++ b/14-supplemental-rstudio.md
@@ -31,7 +31,7 @@ our computer, we'll choose "existing directory":
 ![](fig/RStudio_screenshot_existingdirectory.png)
 &nbsp;
 
-> ## Do you see a "verson control" option? {.callout}
+> ## Do you see a "version control" option? {.callout}
 >
 > Although we're not going to use it here, there should be a "version control"
 > option on this menu. That is what you would click on if you wanted to

--- a/14-supplemental-rstudio.md
+++ b/14-supplemental-rstudio.md
@@ -37,9 +37,10 @@ our computer, we'll choose "existing directory":
 > option on this menu. That is what you would click on if you wanted to
 > create a project on your computer by cloning a repository from github.
 > If that option is not present, it probably means that RStudio doesn't know
-> where your git executable is. See 
+> where your Git executable is. See
 > [this page](https://stat545-ubc.github.io/git03_rstudio-meet-git.html) 
-> for some debugging advice.
+> for some debugging advice. Even if you have Git installed, you may need
+> to accept the XCode license if you are using MacOSX.
   
   
 Next, RStudio will ask which existing directory we want to use. Click "browse"


### PR DESCRIPTION
Learners on MacOSX may need to accept the XCode license prior to the first-time use of Git.

Fixes #193 