### PR TITLE
Recommend against nested git repos

### DIFF
--- a/03-create.md
+++ b/03-create.md
@@ -81,7 +81,7 @@ nothing to commit (create/copy files and use "git add" to track)
 
 Git repositories can interfere with each other if they are "nested" in the directory of another. We therefore advise to create each new git repository in a separate directory. Note that we can track or ignore (as discussed later) files in directories within a git repository as shown:
 ~~~ {.bash}
-touch moon phobos deimos titan    #create moon files
+touch moon phobos deimos titan    # create moon files
 cd ..                             # return to planets directory
 ls moons                          # list contents of the moons directory
 git add moons/*                   # add all contents of planets/moons

--- a/03-create.md
+++ b/03-create.md
@@ -88,5 +88,5 @@ git add moons/*                   # add all contents of planets/moons
 git status                        # show moons files in staging area
 git commit -m "add moon files"    # commit planets/moons to planets git repo
 "moons/*" >> .gitignore           # ignore all files within moons
-> ~~~
+~~~
 

--- a/03-create.md
+++ b/03-create.md
@@ -73,7 +73,20 @@ nothing to commit (create/copy files and use "git add" to track)
 > mkdir moons    # make a sub-directory planets/moons
 > cd moons       # go into planets/moons
 > git init       # make the moons sub-directory a Git repository
+> ls -a          # list full contents of moons sub-directory
 > ~~~
 > 
-> Why is it a bad idea to do this?
+> Notice here that the `planets` project is now also tracking the entire `mars` repository. 
 > How can Dracula "undo" his last `git init`?
+
+Git repositories can interfere with each other if they are "nested" in the directory of another. We therefore advise to create each new git repository in a separate directory. Note that we can track or ignore (as discussed later) files in directories within a git repository as shown:
+~~~ {.bash}
+touch moon phobos deimos titan    #create moon files
+cd ..                             # return to planets directory
+ls moons                          # list contents of the moons directory
+git add moons/*                   # add all contents of planets/moons
+git status                        # show moons files in staging area
+git commit -m "add moon files"    # commit planets/moons to planets git repo
+"moons/*" >> .gitignore           # ignore all files within moons
+> ~~~
+

--- a/03-create.md
+++ b/03-create.md
@@ -79,7 +79,7 @@ nothing to commit (create/copy files and use "git add" to track)
 > Notice here that the `planets` project is now also tracking the entire `mars` repository. 
 > How can Dracula "undo" his last `git init`?
 
-Git repositories can interfere with each other if they are "nested" in the directory of another. We therefore advise to create each new git repository in a separate directory. Note that we can track or ignore (as discussed later) files in directories within a git repository as shown:
+Git repositories can interfere with each other if they are "nested" in the directory of another. We therefore advise to create each new git repository in a separate directory. Note that we can track files in directories within a git repository as shown:
 ~~~ {.bash}
 touch moon phobos deimos titan    # create moon files
 cd ..                             # return to planets directory
@@ -87,6 +87,8 @@ ls moons                          # list contents of the moons directory
 git add moons/*                   # add all contents of planets/moons
 git status                        # show moons files in staging area
 git commit -m "add moon files"    # commit planets/moons to planets git repo
-"moons/*" >> .gitignore           # ignore all files within moons
 ~~~
-
+Similarly, we can ignore (as discussed later) entire directories, such as the moons directory: 
+~~~ {.bash}
+echo moons >> .gitignore           # ignore all files within moons
+~~~


### PR DESCRIPTION
Changed to neutral wording, rather than "bad thing" and added more explicit recommendation against nested repos.

Added `ls -a` to the question to make it easier for participants unfamiliar with the terminal to deduce `rm -rf .git` as the answer (as it will be displayed in the terminal).

Example given below on how to demonstrate how to track within nested directories. I note that inclusion of the later content (ignore) may not be suitable here.