### PR TITLE
Configuration with Text Editors

### DIFF
--- a/02-setup.md
+++ b/02-setup.md
@@ -55,7 +55,12 @@ He also has to set his favorite text editor, following this table:
 
 It is possible to reconfigure the text editor for Git whenever you want to change it.
 
-Note that Vim is the default editor for Git so this is only needed if you have changed it already. If you haven't used Vim before and wish to exit a session, type <kbd>Esc</kbd> then <kbd>:q!</kbd> and <kbd>Enter</kbd>.
+> ## Exiting Vim {.callout}
+>
+> Note that `vim` is the default editor for for many programs, if you haven't used `vim` before and wish to exit a session, type <kbd>Esc</kbd> then <kbd>:q!</kbd> and <kbd>Enter</kbd>.
+>
+
+
 
 The four commands we just ran above only need to be run once: the flag `--global` tells Git
 to use the settings for every project, in your user account, on this computer.

--- a/02-setup.md
+++ b/02-setup.md
@@ -46,7 +46,7 @@ He also has to set his favorite text editor, following this table:
 | Sublime Text (Mac) | `$ git config --global core.editor "subl -n -w"` |
 | Sublime Text (Win, 32-bit install) | `$ git config --global core.editor "'c:/program files (x86)/sublime text 3/sublime_text.exe' -w"` |
 | Sublime Text (Win, 64-bit install) | `$ git config --global core.editor "'c:/program files/sublime text 3/sublime_text.exe' -w"` |
-| Notepad++ (Win)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
+| Notepad++ (Win)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"` `$ alias notepad="'c:/program files (x86)/Notepad++/notepad++.exe'"`|
 | Kate (Linux)       | `$ git config --global core.editor "kate"`       |
 | Gedit (Linux)      | `$ git config --global core.editor "gedit -s -w"`   |
 | Scratch (Linux)       | `$ git config --global core.editor "scratch-text-editor"`  |

--- a/02-setup.md
+++ b/02-setup.md
@@ -51,14 +51,11 @@ He also has to set his favorite text editor, following this table:
 | Gedit (Linux)      | `$ git config --global core.editor "gedit -s -w"`   |
 | Scratch (Linux)       | `$ git config --global core.editor "scratch-text-editor"`  |
 | emacs              | `$ git config --global core.editor "emacs"`   |
-
-It is also possible to configure "Vim" as the text editor for Git if you want to change it back. Note that Vim is the default editor for Git so this is only needed if you have changed it already.
-
-| Default Editor             | Configuration command                            |
-|:-------------------|:-------------------------------------------------|
 | vim                | `$ git config --global core.editor "vim"`   |
 
-If you haven't used Vim before and wish to exit a session, type <kbd>Esc</kbd> then <kbd>:q!</kbd> and <kbd>Enter</kbd>.
+It is possible to reconfigure the text editor for Git whenever you want to change it.
+
+Note that Vim is the default editor for Git so this is only needed if you have changed it already. If you haven't used Vim before and wish to exit a session, type <kbd>Esc</kbd> then <kbd>:q!</kbd> and <kbd>Enter</kbd>.
 
 The four commands we just ran above only need to be run once: the flag `--global` tells Git
 to use the settings for every project, in your user account, on this computer.

--- a/02-setup.md
+++ b/02-setup.md
@@ -32,7 +32,8 @@ $ git config --global color.ui "auto"
 
 (Please use your own name and email address instead of Dracula's. 
 This user name and email will be associated with your subsequent Git activity, 
-which means that any changes pushed to GitHub in a later lesson will include this information. 
+which means that any changes pushed to GitHub in a later lesson will include this information.
+We recommend setting up an account on [GitHub](https://github.com) if you haven't already and using this as your user.name so your computer works with this website in the future (including later in this lesson).
 If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private](https://help.github.com/articles/keeping-your-email-address-private/).)
 
 He also has to set his favorite text editor, following this table:
@@ -48,8 +49,12 @@ He also has to set his favorite text editor, following this table:
 | Notepad++ (Win)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
 | Kate (Linux)       | `$ git config --global core.editor "kate"`       |
 | Gedit (Linux)      | `$ git config --global core.editor "gedit -s -w"`   |
+| Scratch (Linux)       | `$ git config --global core.editor "scratch-text-editor"`  |
 | emacs              | `$ git config --global core.editor "emacs"`   |
+
+It is also possible to configure "Vim" as the text editor for Git if you want to change it back. Note that Vim is the default editor for Git so this is only needed if you have changed it already 
 | vim                | `$ git config --global core.editor "vim"`   |
+If you haven't used Vim before and wish to exit a session, type <kbd>Esc</kbd> then <kbd>:q!</kbd> and <kbd>Enter</kbd>.
 
 The four commands we just ran above only need to be run once: the flag `--global` tells Git
 to use the settings for every project, in your user account, on this computer.

--- a/02-setup.md
+++ b/02-setup.md
@@ -33,7 +33,7 @@ $ git config --global color.ui "auto"
 (Please use your own name and email address instead of Dracula's. 
 This user name and email will be associated with your subsequent Git activity, 
 which means that any changes pushed to GitHub in a later lesson will include this information.
-We recommend setting up an account on [GitHub](https://github.com) if you haven't already and using this as your user.name so your computer works with this website in the future (including later in this lesson).
+Please use the same email address as you use for your [GitHub](https://github.com) if you hav one already or create one later in this lesson.
 If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private](https://help.github.com/articles/keeping-your-email-address-private/).)
 
 He also has to set his favorite text editor, following this table:

--- a/02-setup.md
+++ b/02-setup.md
@@ -52,10 +52,12 @@ He also has to set his favorite text editor, following this table:
 | Scratch (Linux)       | `$ git config --global core.editor "scratch-text-editor"`  |
 | emacs              | `$ git config --global core.editor "emacs"`   |
 
-It is also possible to configure "Vim" as the text editor for Git if you want to change it back. Note that Vim is the default editor for Git so this is only needed if you have changed it already 
+It is also possible to configure "Vim" as the text editor for Git if you want to change it back. Note that Vim is the default editor for Git so this is only needed if you have changed it already.
+
 | Default Editor             | Configuration command                            |
 |:-------------------|:-------------------------------------------------|
 | vim                | `$ git config --global core.editor "vim"`   |
+
 If you haven't used Vim before and wish to exit a session, type <kbd>Esc</kbd> then <kbd>:q!</kbd> and <kbd>Enter</kbd>.
 
 The four commands we just ran above only need to be run once: the flag `--global` tells Git

--- a/02-setup.md
+++ b/02-setup.md
@@ -53,6 +53,8 @@ He also has to set his favorite text editor, following this table:
 | emacs              | `$ git config --global core.editor "emacs"`   |
 
 It is also possible to configure "Vim" as the text editor for Git if you want to change it back. Note that Vim is the default editor for Git so this is only needed if you have changed it already 
+| Default Editor             | Configuration command                            |
+|:-------------------|:-------------------------------------------------|
 | vim                | `$ git config --global core.editor "vim"`   |
 If you haven't used Vim before and wish to exit a session, type <kbd>Esc</kbd> then <kbd>:q!</kbd> and <kbd>Enter</kbd>.
 

--- a/02-setup.md
+++ b/02-setup.md
@@ -57,7 +57,7 @@ It is possible to reconfigure the text editor for Git whenever you want to chang
 
 > ## Exiting Vim {.callout}
 >
-> Note that `vim` is the default editor for for many programs, if you haven't used `vim` before and wish to exit a session, type <kbd>Esc</kbd> then <kbd>:q!</kbd> and <kbd>Enter</kbd>.
+> Note that `vim` is the default editor for for many programs, if you haven't used `vim` before and wish to exit a session, type `Esc` then `:q!` and `Enter`.
 >
 
 


### PR DESCRIPTION
	Changes to text editor configuration  …
Updated config to recommend github account as user.name

Added Scratch (Linux) as a text editor for Linux users, this is the default editor for Elementary OS.

Noted that Vim is the default editor, previous Vim users have asked helpers to configure it instead of nano (which we usually demonstrate in the workshop). Included instructions for novices to exit Vim if configuration unintentionally left on default.