### PR TITLE
Use Git instead of git

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -237,7 +237,7 @@ $ git checkout f22b25e mars.txt
 > {: .bash}
 >
 > to revert mars.txt to its state after the commit f22b25e.
-> If you forget `mars.txt` in that command, git will tell you that "You are in
+> If you forget `mars.txt` in that command, Git will tell you that "You are in
 > 'detached HEAD' state." In this state, you shouldn't make any changes.
 > You can fix this by reattaching your head using ``git checkout master``
 {: .callout}


### PR DESCRIPTION
We try to use Git, with capital G, when referencing to the "protocol"
and git, with lower G, when referencing to the "implementation".