### PR TITLE
Update notepad++ instructions

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -51,7 +51,8 @@ He also has to set his favorite text editor, following this table:
 | Sublime Text (Mac) | `$ git config --global core.editor "subl -n -w"` |
 | Sublime Text (Win, 32-bit install) | `$ git config --global core.editor "'c:/program files (x86)/sublime text 3/sublime_text.exe' -w"` |
 | Sublime Text (Win, 64-bit install) | `$ git config --global core.editor "'c:/program files/sublime text 3/sublime_text.exe' -w"` |
-| Notepad++ (Win)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"` `$ alias notepad="'c:/program files (x86)/Notepad++/notepad++.exe'"`|
+| Notepad++ (Win, 32-bit install)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
+| Notepad++ (Win, 64-bit install)    | `$ git config --global core.editor "'c:/program files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
 | Kate (Linux)       | `$ git config --global core.editor "kate"`       |
 | Gedit (Linux)      | `$ git config --global core.editor "gedit -s -w"`   |
 | Scratch (Linux)       | `$ git config --global core.editor "scratch-text-editor"`  |


### PR DESCRIPTION
When trying with one of my Ph.D. student, I discover the double lines (that the patch remove) are troubling for beginners.
Also, the alias seemed unrelated.
This patch also adds the 32bit/64bit variations.

Edited from github... so it needs a second eye review.