### PR TITLE
Adding auto-generated IDs to glossary

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -12,6 +12,7 @@ permalink: /reference/
 
 ## Glossary
 
+{:auto_ids}
 change set
 :   A group of changes to one or more files that are or will be added
     to a single [commit](#commit) in a [version control](#version-control)


### PR DESCRIPTION
The new version of Kramdown will add IDs to glossary entries (definition lists) if instructed to do so.