### PR TITLE
update gedit config

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -54,7 +54,7 @@ He also has to set his favorite text editor, following this table:
 | Notepad++ (Win, 32-bit install)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
 | Notepad++ (Win, 64-bit install)    | `$ git config --global core.editor "'c:/program files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
 | Kate (Linux)       | `$ git config --global core.editor "kate"`       |
-| Gedit (Linux)      | `$ git config --global core.editor "gedit -s -w"`   |
+| Gedit (Linux)      | `$ git config --global core.editor "gedit --wait --new-window"`   |
 | Scratch (Linux)       | `$ git config --global core.editor "scratch-text-editor"`  |
 | emacs              | `$ git config --global core.editor "emacs"`   |
 | vim                | `$ git config --global core.editor "vim"`   |


### PR DESCRIPTION
It seems that gedit command line interface is a moving target. After the fix #174 from January 2016, now it's again broken! On Ubuntu 16.04 with gedit (v 3.18) and Debian testing (v 3.22), the `gedit -w -s` call yields:

    Failed to register: GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod:
    Method "DescribeAll" with signature "" on interface "org.gtk.Actions" doesn't exist

I found a report for this issue (https://bugzilla.gnome.org/show_bug.cgi?id=742469) from Jan 2015. Apparently for gedit 3.14. It's not yet fixed, but a workaround is suggested, to replace the '-s' (standalone) option by 'new-window'. New git config looks like:

    $ git config --global core.editor "gedit --wait --new-window"

I've tested one commit message (with one extra gedit window previously opened to check the new-window option) and it seems to work fine. I think 02-setup.md should be updated accordingly.