### PR TITLE
Tracking Changes: 2 notes about directories in Git

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -538,6 +538,38 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > {: .output}
 {: .callout}
 
+> ## Directories
+>
+> Two important facts you should know about directories in Git.
+>
+> 1. Git does not track directories on their own, only files within them.
+> Try it for yourself:
+>
+> ~~~
+> mkdir directory
+> git status
+> git add directory
+> git status
+> ~~~
+> {: .bash}
+> 
+> Note, our newly created empty directory `directory` does not appear in
+> the list of untracked files even if we explicitly add it (_via_ `git add`) to our
+> repository. This is the reason why you will sometimes see `.gitkeep` files
+> in otherwise empty directories. Unlike `.gitignore`, these files are not special
+> and their sole purpose is to populate a directory so that Git adds it to
+> the repository. In fact, you can name such files anything you like.
+>
+> 2. If you create a directory in your Git repository and populate it with files,
+> you can add all files in the directory at once by:
+>
+> ~~~
+> git add <directory-with-files>
+> ~~~
+> {: .bash}
+>
+{: .callout}
+
 To recap, when we want to add changes to our repository,
 we first need to add the changed files to the staging area
 (`git add`) and then commit the staged changes to the


### PR DESCRIPTION
Added two notes about directories in Git.
1. Directories on their own are not tracked.
2. When you do `git add <directory>`, you effectively add all the files
within that directory.