### PR TITLE
Avoid early mention of `mars` repository

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -87,7 +87,7 @@ nothing to commit (create/copy files and use "git add" to track)
 > ~~~
 > {: .bash}
 >
-> Why is it a bad idea to do this? (Notice here that the `planets` project is now also tracking the entire `mars` repository.)
+> Why is it a bad idea to do this? (Notice here that the `planets` project is now also tracking the entire `moons` repository.)
 > How can Dracula undo his last `git init`?
 >
 > > ## Solution

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -499,7 +499,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > $ git log -1
 > ~~~
 > {: .bash}
-> 
+>
 > ~~~
 > commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
 > Author: Vlad Dracula <vlad@tran.sylvan.ia>
@@ -568,10 +568,10 @@ repository (`git commit`):
 >
 > 1. `$ git commit -m "my recent changes"`
 >
-> 2. `$ git init myfile.txt`  
+> 2. `$ git init myfile.txt`
 >    `$ git commit -m "my recent changes"`
 >
-> 3. `$ git add myfile.txt`  
+> 3. `$ git add myfile.txt`
 >    `$ git commit -m "my recent changes"`
 >
 > 4. `$ git commit -m myfile.txt "my recent changes"`

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -484,7 +484,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > *   To get out of the pager, press `q`.
 > *   To move to the next page, press the space bar.
 > *   To search for `some_word` in all pages, type `/some_word`
->     and navigate throught matches pressing `n`.
+>     and navigate through the matches pressing `n`.
 {: .callout}
 
 > ## Limit Log Size


### PR DESCRIPTION
At this point in the lesson, the `mars` repository has not been mentioned. Rather, it's the `moons` repo that was created nested in the example.