### PR TITLE
git initialization missing

### DIFF
--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -22,7 +22,7 @@ $ touch a.dat b.dat c.dat results/a.out results/b.out
 ~~~
 {: .bash}
 
-and see what Git says:
+and after initializing Git, see what Git says:
 
 ~~~
 $ git status


### PR DESCRIPTION
Better to **clearly** mention about `$git init` - git initialization before git status command.