### PR TITLE
Update link to git cheat sheet

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -5,7 +5,8 @@ permalink: /reference/
 
 ## Git Cheatsheets for Quick Reference
 
-*   A great [printable git cheatsheet](https://services.github.com/resources/) is available in PDF from the GitHub training website.
+*   A great [printable git cheatsheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf) is available in PDF from the
+[GitHub training website](https://services.github.com/resources/).
 *   An [interactive one-page visualisation](http://ndpsoftware.com/git-cheatsheet.html)
     about the relationships between workspace, staging area, local repository, upstream repository, and the commands associated with each (with explanations).
 *   Both resources are also available in other languages e.g. Spanish, French, and more


### PR DESCRIPTION
The link pointed to training site.
Now one link points explicitly to the pdf and one to training site.