### PR TITLE
Gitignore notes and word-based diffing

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -474,6 +474,14 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 ~~~
 {: .output}
 
+> ## Word-based diffing
+>
+> Sometimes, e.g. in the case of the text documments a line-wise
+> diff is too coarse. That is where the `--color-words` option of
+> `git diff` comes in very useful as it highlights the changed 
+> words using colors.
+{: .callout}
+
 > ## Paging the Log
 >
 > When the output of `git log` is too long to fit in your screen,

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -168,6 +168,9 @@ nothing to commit, working directory clean
 > > and create an exception for the `results/data/` folder.
 > > The next challenge will cover this type of solution.
 > >
+> > Sometimes the `**` pattern comes in handy, too, which matches
+> > multiple directory levels. E.g. `**/results/plots/*` would make git ignore
+> > the `results/plots` directory in any root directory.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
- Added some notes about `git://` and ssh proxy
- Added a note about `**` pattern in gitignore section
- Mention `--color-words` option in diff section, which is extremely useful for LaTeX files.