### PR TITLE
Update 04-changes.md

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -19,9 +19,9 @@ keypoints:
 
 Let's create a file called `mars.txt` that contains some notes
 about the Red Planet's suitability as a base.
-(We'll use `nano` to edit the file;
+We'll use `nano` to edit the file;
 you can use whatever editor you like.
-In particular, this does not have to be the `core.editor` you set globally earlier.)
+In particular, this does not have to be the `core.editor` you set globally earlier. But remember, the bash command to create or edit a new file will depend on the editor you choose (it might not be `nano`). For a refresher on text editors, check out ["Which Editor?"](https://swcarpentry.github.io/shell-novice/03-create/) in [The Unix Shell](https://swcarpentry.github.io/shell-novice/) lesson.
 
 ~~~
 $ nano mars.txt


### PR DESCRIPTION
In the beginning instructions on creating and editing a file in the newly initiated repo, I have added a reminder that the bash command to open or edit text editors depends on the editor you choose. I link back to the more thorough discussion of text editors in The Unix Shell lesson (third episode). 

I find that students, particularly those new to command line interfaces, often get tripped up on opening, editing, and closing text editors. My edit is an attempt to remind students to double-check and clarify that they'll need to select their editor and the right command that goes with it.