### PR TITLE
05: git log with 2 commits doesn't make much sense 

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -517,7 +517,7 @@ moving backward and forward in time becomes much easier.
 > Question: What does the following command do?
 >
 > ~~~
-> $ git log --patch HEAD~3 HEAD~1 *.txt
+> $ git log --patch HEAD~3 *.txt
 > ~~~
 > {: .bash}
 {: .challenge}


### PR DESCRIPTION
git log with 2 commits doesn't make much sense. I think this is an artifact from 6e5f4aac0df66d6ad7bcca0f769917d65e622b97, which replaced "git diff --stat" with "git log --patch".