### PR TITLE
Add private email notes for GitHub

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -31,16 +31,17 @@ $ git config --global color.ui "auto"
 ~~~
 {: .bash}
 
-Please use your own name and email address instead of Dracula's. This should be the same address you used when setting up GitHub. If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private][git-privacy]. 
-If you elect to use a private email address with GitHub, then use that same email address for the `user.email` value, e.g. `username@users.noreply.github.com` with your `username`.
-
-This user name and email will be associated with your subsequent Git activity,
+Please use your own name and email address instead of Dracula's. This user name and email will be associated with your subsequent Git activity,
 which means that any changes pushed to
 [GitHub](http://github.com/),
 [BitBucket](http://bitbucket.org/),
 [GitLab](http://gitlab.com/) or
 another Git host server
 in a later lesson will include this information.
+
+For these lessons, we will be interacting with [GitHub](http://github.com/) and so the email address used should be the same as the one used when setting up your GitHub account. If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private][git-privacy]. 
+If you elect to use a private email address with GitHub, then use that same email address for the `user.email` value, e.g. `username@users.noreply.github.com` replacing `username` with your GitHub one. You can change the email address later on by using the `git config` command again.
+
 
 He also has to set his favorite text editor, following this table:
 

--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -31,7 +31,9 @@ $ git config --global color.ui "auto"
 ~~~
 {: .bash}
 
-Please use your own name and email address instead of Dracula's.
+Please use your own name and email address instead of Dracula's. This should be the same address you used when setting up GitHub. If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private][git-privacy]. 
+If you elect to use a private email address with GitHub, then use that same email address for the `user.email` value, e.g. `username@users.noreply.github.com` with your `username`.
+
 This user name and email will be associated with your subsequent Git activity,
 which means that any changes pushed to
 [GitHub](http://github.com/),
@@ -39,7 +41,6 @@ which means that any changes pushed to
 [GitLab](http://gitlab.com/) or
 another Git host server
 in a later lesson will include this information.
-If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private][git-privacy].
 
 He also has to set his favorite text editor, following this table:
 


### PR DESCRIPTION
Adds clarity that when using a private email address with GitHub, that address needs to be uses for user.email