### PR TITLE
Small clean up of glossary

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -335,7 +335,7 @@ but *not* commit the work we're doing on the conclusion
 To allow for this,
 Git has a special *staging area*
 where it keeps track of things that have been added to
-the current [change set]({{ page.root }}/reference/#change-set)
+the current [changeset]({{ page.root }}/reference/#changeset)
 but not yet committed.
 
 > ## Staging Area

--- a/reference.md
+++ b/reference.md
@@ -14,15 +14,15 @@ permalink: /reference/
 ## Glossary
 
 {:auto_ids}
-change set
+changeset
 :   A group of changes to one or more files that are or will be added
     to a single [commit](#commit) in a [version control](#version-control)
     [repository](#repository).
 
 commit
-:   To record the current state of a set of files (a [change set](#change-set))
+:   To record the current state of a set of files (a [changeset](#changeset))
     in a [version control](#version-control) [repository](#repository). As a noun,
-    the result of committing, i.e. a recorded change set in a repository.
+    the result of committing, i.e. a recorded changeset in a repository.
     If a commit contains changes to multiple files,
     all of the changes are recorded together.
 

--- a/reference.md
+++ b/reference.md
@@ -36,13 +36,6 @@ HTTP
 :   The Hypertext Transfer [Protocol](#protocol) used for sharing web pages and other data
     on the World Wide Web.
 
-infective license
-:   A license, such as the [GPL](http://opensource.org/licenses/GPL-3.0),
-    that legally requires people who incorporate material under the
-    infective license
-    into their own work to also release under the same infective license
-    (e.g. under the GPL license).
-
 merge
 :   (a repository): To reconcile two sets of changes to a
     [repository](#repository).


### PR DESCRIPTION
This removes 'infective license' from the glossary, as it's not used anywhere (having been removed from the licence discussion through #226, and switches to 'changeset' over 'change set', which appears to be what both git and wikipedia use.