### PR TITLE
Add merge conflict avoidance strategies

### DIFF
--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -297,13 +297,22 @@ We don't need to merge again because Git knows someone has already done that.
 Git's ability to resolve conflicts is very useful, but conflict resolution
 costs time and effort, and can introduce errors if conflicts are not resolved
 correctly. If you find yourself resolving a lot of conflicts in a project,
-consider one of these approaches to reducing them:
+consider these technical approaches to reducing them:
 
-- Try breaking large files apart into smaller files so that it is less
-  likely that two authors will be working in the same file at the same time
+- Pull from upstream more frequently, especially before starting new work
+- Use topic branches to segregate work, merging to master when complete
+- Make smaller more atomic commits
+- Where logically appropriate, break large files into smaller ones so that it is
+  less likely that two authors will alter the same file simultaneously
+
+Conflicts can also be minimized with project management strategies:
+
 - Clarify who is responsible for what areas with your collaborators
 - Discuss what order tasks should be carried out in with your collaborators so
-  that tasks that will change the same file won't be worked on at the same time
+  that tasks expected to change the same lines won't be worked on simultaneously
+- If the conflicts are stylistic churn (e.g. tabs vs. spaces), establish a
+  project convention that is governing and use code style tools (e.g.
+  `htmltidy`, `perltidy`, `rubocop`, etc.) to enforce, if necessary
 
 > ## Solving Conflicts that You Create
 >


### PR DESCRIPTION
- include simple preventative steps before getting to breaking up files (which doesn't actually solve anything if the same lines will be logically revised together anyway)
- separate technical and social strategies
- I understand the lesson currently de-empasizes branching, but it would be a disservice to avoid referencing it here, at a minimum, since putting work on a branch is exactly how one would implement the project management strategy of scheduling "this before that", without  blocking the developer.

Honestly, if you have conflicts with collaborators and you aren't using branching, it is the **first** thing I would recommend. I downplay it here, but the inevitability of conflicts is a prime motivation.