### PR TITLE
corrected typo in exiting Vim section

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -64,7 +64,7 @@ It is possible to reconfigure the text editor for Git whenever you want to chang
 
 > ## Exiting Vim
 >
-> Note that `vim` is the default editor for for many programs, if you haven't used `vim` before and wish to exit a session, type `Esc` then `:q!` and `Enter`.
+> Note that `vim` is the default editor for many programs. If you haven't used `vim` before and wish to exit a session, type `Esc` then `:q!` and `Enter`.
 {: .callout}
 
 The four commands we just ran above only need to be run once: the flag `--global` tells Git


### PR DESCRIPTION
Just a quick correction to make the 'exiting Vim' section read more smoothly.