### PR TITLE
Tell students that git version differences are ok

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -61,6 +61,9 @@ $ git status
 ~~~
 {: .bash}
 
+If you are using a different version of git than I am, then then the exact
+wording of the output might be slightly different.
+
 ~~~
 # On branch master
 #


### PR DESCRIPTION
If not warned, then students can get all uptight if there is a slight difference in the wording of the git output.
