### PR TITLE
Explicitly call module out as supplemental

### DIFF
--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -1,5 +1,5 @@
 ---
-title: Using Git from RStudio
+title: Supplemental: Using Git from RStudio
 teaching: 10
 exercises: 0
 questions:


### PR DESCRIPTION
I was just asked by an instructor if they had to teach the RStudio episode of the Git lesson, as the schedule looks now, it looks that way. I added the word "supplemental" to note that it is not a required episode when viewing the schedule.