### PR TITLE
Add double quotes around title

### DIFF
--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -1,5 +1,5 @@
 ---
-title: Supplemental: Using Git from RStudio
+title: "Supplemental: Using Git from RStudio"
 teaching: 10
 exercises: 0
 questions:


### PR DESCRIPTION
Prevents a YAML exception.
Fixes #466 