### PR TITLE
Update 09-conflict.md

### DIFF
--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -133,8 +133,8 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 
 ![The Conflicting Changes](../fig/conflict.svg)
 
-Git detects that the changes made in one copy overlap with those made in the other
-and stops us from trampling on our previous work.
+Git rejects the push because it detects that the remote repository has new updates that have not been
+incorporated into the local branch.
 What we have to do is pull the changes from GitHub,
 [merge]({{ page.root }}/reference/#merge) them into the copy we're currently working in,
 and then push that.
@@ -158,8 +158,12 @@ Automatic merge failed; fix conflicts and then commit the result.
 ~~~
 {: .output}
 
-`git pull` tells us there's a conflict,
-and marks that conflict in the affected file:
+The `git pull` command combines a `git fetch` with a `git merge` to update the local repository to include
+changes already included in the remote repository.
+After the changes from remote branch have been fetched, Git detects that changes made to the local copy 
+overlap with those made to the remote repository, and therefore refuses to merge the two versions to
+stop us from trampling on our previous work. The conflict is marked in
+in the affected file:
 
 ~~~
 $ cat mars.txt

--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -158,7 +158,7 @@ Automatic merge failed; fix conflicts and then commit the result.
 ~~~
 {: .output}
 
-The `git pull` command combines a `git fetch` with a `git merge` to update the local repository to include
+The `git pull` command updates the local repository to include those
 changes already included in the remote repository.
 After the changes from remote branch have been fetched, Git detects that changes made to the local copy 
 overlap with those made to the remote repository, and therefore refuses to merge the two versions to


### PR DESCRIPTION
These changes clarify when a merge conflict is identified by git. In this case, the git push command fails not because of the merge conflict, but because the remote repository has newer changes that have not yet been incorporated into the local repository. Even if a merge conflict does not exist, git pull will fail in this scenario. The merge conflict is only identified after git fetch retrieves the changes made to the remote repository into the local version and then attempts to merge the two versions with git merge.  This necessitates manual intervention to complete the failed merge operation.

These changes are part of my software carpentry instructor training checkout process.
