### PR TITLE
Add why a detached head state happens in 05-history.md

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -284,8 +284,10 @@ $ git checkout HEAD mars.txt
 > ~~~
 > {: .bash}
 >
-> to revert `mars.txt` to its state after the commit `f22b25e`.
-> If you forget `mars.txt` in that command, Git will tell you that "You are in
+> to revert `mars.txt` to its state after the commit `f22b25e`. But be careful! 
+> The command `checkout` has other important functionalities and Git will misunderstand
+> your intentions if you are not accurate with the typing. For example, 
+> if you forget `mars.txt` in that command, Git will tell you that "You are in
 > 'detached HEAD' state." In this state, you shouldn't make any changes.
 > You can fix this by reattaching your head using ``git checkout master``
 {: .callout}


### PR DESCRIPTION
Add a simple phrase under "Don't lose your head" to clarify that 'checkout' is not only used to restore old versions of files, and that's why a detached head state can occur.

I noticed during three SC git courses that some trainees thought that the 'detached head state' was a way of Git to tell them they were not able to use the command properly, a sort of judgment on their mental confusion!

I did not mention branches in the phrase that I am proposing because they are not explicitly explained before, but I hope that with this little generic clarification at least people are aware that 'checkout' means also something else and that's why they make a mess if the file name is missing.

This contribution is part of my instructor training checkout.