### PR TITLE
Fix typo in directory name when removing empty repo

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -130,7 +130,7 @@ nothing to commit (create/copy files and use "git add" to track)
 > > ## Solution -- USE WITH CAUTION!
 > >
 > > To recover from this little mistake, Dracula can just remove the `.git`
-> > folder in the moons subdirectory by running the following command from inside the 'moons' directory:
+> > folder in the moons subdirectory by running the following command from inside the 'planets' directory:
 > >
 > > ~~~
 > > $ rm -rf moons/.git


### PR DESCRIPTION
In one of the assignments of episode 3 the student is asked to greate
a repository inside another one and then remove it. The solution uses
the wrong directory name from where to run the rm command.

This fixes Issue #488.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
