### PR TITLE
Ensure Sublime works without symlinking (related to #360)

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -81,7 +81,7 @@ Dracula also has to set his favorite text editor, following this table:
 | Atom | `$ git config --global core.editor "atom --wait"`|
 | nano               | `$ git config --global core.editor "nano -w"`    |
 | BBEdit (Mac, with command line tools) | `$ git config --global core.editor "bbedit -w"`    |
-| Sublime Text (Mac) | `$ git config --global core.editor "subl -n -w"` |
+| Sublime Text (Mac) | `$ git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl -n -w"` |
 | Sublime Text (Win, 32-bit install) | `$ git config --global core.editor "'c:/program files (x86)/sublime text 3/sublime_text.exe' -w"` |
 | Sublime Text (Win, 64-bit install) | `$ git config --global core.editor "'c:/program files/sublime text 3/sublime_text.exe' -w"` |
 | Notepad++ (Win, 32-bit install)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|


### PR DESCRIPTION
Hello :-)

The provided command did not work on my macOS 10.13.3 with Sublime 3.0. https://stackoverflow.com/a/22632139 helped and explained that for the original command to work, a symlink had to be set up. To avoid pushing that to learner, but still providing a working command, I suggest to mirror the SO solution.