### PR TITLE
03-create.md: fix motivatingexample img path

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -17,7 +17,7 @@ we can start using it.
 We will continue with the story of Wolfman and Dracula who are investigating if it
 is possible to send a planetary lander to Mars. 
 
-![motivatingexample](./fig/motivatingexample.png)
+![motivatingexample](../fig/motivatingexample.png)
 
 
 First, let's create a directory for our work and then move into that directory:


### PR DESCRIPTION
This should fix the relative path to the motivatingexample.png image that currently appears to result in a broken image.