### PR TITLE
Issue #507 - Episode 14 - Added guidance for RStudio users when Git.exe path not pre-filled

### DIFF
--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -37,9 +37,22 @@ our computer, we choose the option "Existing Directory":
 > option on this menu. That is what you would click on if you wanted to
 > create a project on your computer by cloning a repository from GitHub.
 > If that option is not present, it probably means that RStudio doesn't know
-> where your Git executable is. See
-> [this page](https://stat545-ubc.github.io/git03_rstudio-meet-git.html)
-> for some debugging advice. Even if you have Git installed, you may need
+> where your Git executable is, and you won't be able to progress further
+> in this lesson until you tell RStudio where it is.  
+> # Find your Git Executiable
+> First make sure that you have installed either [Git](https://git-scm.com/downloads/)
+> or [GitHub](https://desktop.github.com/) on your computer.
+> Next, open your shell on Mac or Linux, or on Windows open the command prompt.
+> and then type:
+> - 'which git' (Mac, Linux)
+> - 'where git' (Windows)
+> Copy the path to the git executable (e.g. On a Windows computer the path was:
+> 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
+> # Tell RStudio where to find GitHub
+> In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
+> browse to the git executable you found in the command prompt or shell. Now restart
+> RStudio.
+> Note: Even if you have Git installed, you may need
 > to accept the XCode license if you are using macOS.
 {: .callout}
 
@@ -98,7 +111,7 @@ history:
 > - 'where git' (Windows)
 > Copy the path to the git executable (e.g. On a Windows computer the path was:
 > 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
-> <b>Tell RStudio where to find GitHub</b>
+> # Tell RStudio where to find GitHub
 > In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
 > browse to the git executable you found in the command prompt or shell. Now restart
 > RStudio.

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -47,7 +47,7 @@ our computer, we choose the option "Existing Directory":
 > - `which git` (Mac, Linux)
 > - `where git` (Windows)
 > Copy the path to the git executable (e.g. On a Windows computer the path was:
-> 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
+> `C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe`)
 > ### Tell RStudio where to find GitHub
 > In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
 > browse to the git executable you found in the command prompt or shell. Now restart
@@ -94,29 +94,12 @@ history:
 
 ![](../fig/RStudio_screenshot_history.png)
 
-> ## Do You See a "Version Control" Option?
+> ## Are the Push/Pull Commands Grayed Out?
 >
-> Although we're not going to use it here, there should be a "version control"
-> option on this menu. That is what you would click on if you wanted to
-> create a project on your computer by cloning a repository from GitHub.
-> If that option is not present, it probably means that RStudio doesn't know
-> where your Git executable is, and you won't be able to progress further
-> in this lesson until you tell RStudio where it is.  
-> # Find your Git Executiable
-> First make sure that you have installed either [Git](https://git-scm.com/downloads/)
-> or [GitHub](https://desktop.github.com/) on your computer.
-> Next, open your shell on Mac or Linux, or on Windows open the command prompt.
-> and then type:
-> - 'which git' (Mac, Linux)
-> - 'where git' (Windows)
-> Copy the path to the git executable (e.g. On a Windows computer the path was:
-> 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
-> # Tell RStudio where to find GitHub
-> In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
-> browse to the git executable you found in the command prompt or shell. Now restart
-> RStudio.
-> Note: Even if you have Git installed, you may need
-> to accept the XCode license if you are using macOS.
+> Grayed out Push/Pull commands generally mean that RStudio doesn't know the
+> location of your remote repository (e.g. on GitHub). To fix this, open a
+> terminal to the repository and enter the command: `git push -u origin
+> master`. Then restart RStudio.
 {: .callout}
 
 If we click on "History", we can see a graphical version of what `git log`

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -46,7 +46,8 @@ our computer, we choose the option "Existing Directory":
 > and then type:
 > - `which git` (Mac, Linux)
 > - `where git` (Windows)
-> Copy the path to the git executable (e.g. On a Windows computer the path was:
+> Copy the path to the git executable (e.g. On one Windows computer which had
+> GitHub Desktop installed on it, the path was:
 > `C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe`)
 > ### Tell RStudio where to find GitHub
 > In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -44,8 +44,8 @@ our computer, we choose the option "Existing Directory":
 > or [GitHub](https://desktop.github.com/) on your computer.
 > Next, open your shell on Mac or Linux, or on Windows open the command prompt.
 > and then type:
-> - `which git' (Mac, Linux)
-> - `where git' (Windows)
+> - `which git` (Mac, Linux)
+> - `where git` (Windows)
 > Copy the path to the git executable (e.g. On a Windows computer the path was:
 > 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
 > ### Tell RStudio where to find GitHub

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -98,7 +98,7 @@ history:
 > - 'where git' (Windows)
 > Copy the path to the git executable (e.g. On a Windows computer the path was:
 > 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
-> # Tell RStudio where to find GitHub
+> <b>Tell RStudio where to find GitHub</b>
 > In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
 > browse to the git executable you found in the command prompt or shell. Now restart
 > RStudio.

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -39,7 +39,7 @@ our computer, we choose the option "Existing Directory":
 > If that option is not present, it probably means that RStudio doesn't know
 > where your Git executable is, and you won't be able to progress further
 > in this lesson until you tell RStudio where it is.  
-> # Find your Git Executiable
+> ### Find your Git Executiable
 > First make sure that you have installed either [Git](https://git-scm.com/downloads/)
 > or [GitHub](https://desktop.github.com/) on your computer.
 > Next, open your shell on Mac or Linux, or on Windows open the command prompt.
@@ -48,7 +48,7 @@ our computer, we choose the option "Existing Directory":
 > - 'where git' (Windows)
 > Copy the path to the git executable (e.g. On a Windows computer the path was:
 > 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
-> # Tell RStudio where to find GitHub
+> ### Tell RStudio where to find GitHub
 > In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
 > browse to the git executable you found in the command prompt or shell. Now restart
 > RStudio.

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -48,7 +48,8 @@ our computer, we choose the option "Existing Directory":
 > - `where git` (Windows)
 > Copy the path to the git executable (e.g. On one Windows computer which had
 > GitHub Desktop installed on it, the path was:
-> `C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe`)
+> `C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe`
+> NOTE: The path on your computer will be different)
 > ### Tell RStudio where to find GitHub
 > In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
 > browse to the git executable you found in the command prompt or shell. Now restart

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -81,12 +81,29 @@ history:
 
 ![](../fig/RStudio_screenshot_history.png)
 
-> ## Are the Push/Pull Commands Grayed Out?
+> ## Do You See a "Version Control" Option?
 >
-> Grayed out Push/Pull commands generally mean that RStudio doesn't know the
-> location of your remote repository (e.g. on GitHub). To fix this, open a
-> terminal to the repository and enter the command: `git push -u origin
-> master`. Then restart RStudio.
+> Although we're not going to use it here, there should be a "version control"
+> option on this menu. That is what you would click on if you wanted to
+> create a project on your computer by cloning a repository from GitHub.
+> If that option is not present, it probably means that RStudio doesn't know
+> where your Git executable is, and you won't be able to progress further
+> in this lesson until you tell RStudio where it is.  
+> # Find your Git Executiable
+> First make sure that you have installed either [Git](https://git-scm.com/downloads/)
+> or [GitHub](https://desktop.github.com/) on your computer.
+> Next, open your shell on Mac or Linux, or on Windows open the command prompt.
+> and then type:
+> - 'which git' (Mac, Linux)
+> - 'where git' (Windows)
+> Copy the path to the git executable (e.g. On a Windows computer the path was:
+> 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
+> # Tell RStudio where to find GitHub
+> In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
+> browse to the git executable you found in the command prompt or shell. Now restart
+> RStudio.
+> Note: Even if you have Git installed, you may need
+> to accept the XCode license if you are using macOS.
 {: .callout}
 
 If we click on "History", we can see a graphical version of what `git log`

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -40,16 +40,21 @@ our computer, we choose the option "Existing Directory":
 > where your Git executable is, and you won't be able to progress further
 > in this lesson until you tell RStudio where it is.  
 > ### Find your Git Executiable
-> First make sure that you have installed either [Git](https://git-scm.com/downloads/)
-> or [GitHub](https://desktop.github.com/) on your computer.
-> Next, open your shell on Mac or Linux, or on Windows open the command prompt.
+> First let's make sure that Git is installed on your computer.
+> Open your shell on Mac or Linux, or on Windows open the command prompt
 > and then type:
 > - `which git` (Mac, Linux)
 > - `where git` (Windows)
-> Copy the path to the git executable (e.g. On one Windows computer which had
-> GitHub Desktop installed on it, the path was:
+>
+> If there is no version of Git on your computer, please either install [Git](https://git-scm.com/downloads/)
+> or [GitHub](https://desktop.github.com/) now. Next open your shell or command prompt 
+> and type `which git` (Mac, Linux), or `where git` (Windows).
+> Copy the path to the git executable.
+>
+> e.g. On one Windows computer which had GitHub Desktop installed on it, the path was:
 > `C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe`
-> NOTE: The path on your computer will be different)
+> 
+> NOTE: The path on your computer will be somewhat different.
 > ### Tell RStudio where to find GitHub
 > In RStudio, go to the `Tools` menu > `Global Options` > `Git/SVN` and then
 > browse to the git executable you found in the command prompt or shell. Now restart

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -44,8 +44,8 @@ our computer, we choose the option "Existing Directory":
 > or [GitHub](https://desktop.github.com/) on your computer.
 > Next, open your shell on Mac or Linux, or on Windows open the command prompt.
 > and then type:
-> - 'which git' (Mac, Linux)
-> - 'where git' (Windows)
+> - `which git' (Mac, Linux)
+> - `where git' (Windows)
 > Copy the path to the git executable (e.g. On a Windows computer the path was:
 > 'C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe')
 > ### Tell RStudio where to find GitHub

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -51,7 +51,7 @@ our computer, we choose the option "Existing Directory":
 > `C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe`
 > NOTE: The path on your computer will be different)
 > ### Tell RStudio where to find GitHub
-> In RStudio, go to the 'Tools' menu > 'Global Options' > 'Git/SVN' and then
+> In RStudio, go to the `Tools` menu > `Global Options` > `Git/SVN` and then
 > browse to the git executable you found in the command prompt or shell. Now restart
 > RStudio.
 > Note: Even if you have Git installed, you may need


### PR DESCRIPTION
In response to Issue #507 [](https://github.com/swcarpentry/git-novice/issues/507) I added some text to Episode 14 to give some direction to users when the Git executable path in RStudio is not pre-filled for them.  This seems to be more of a problem on Windows computers.
