### PR TITLE
DOC: Clarify nested nature of git init & separation from directory creation

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -37,6 +37,13 @@ $ git init
 ~~~
 {: .bash}
 
+It is important to note that `git init` will create a repository that
+includes subdirectories and their files---there is no need to create
+separate repositories nested within the `planets` repository, whether
+subdirectories are present from the beginning or added later. Also, note
+that the creation of the `planets` directory and its initialization as a
+repository are completely separate processes.
+
 If we use `ls` to show the directory's contents,
 it appears that nothing has changed:
 


### PR DESCRIPTION
Fixes #526.

As discussed in the linked issue, clearly explaining that `git init` includes subdirectories is useful, especially given that the episode allocates 0 minutes to the exercises that explore this.

I've also reiterated that directory creation and repository initialization are completely separate processes, which is also considered a useful point in the linked issue.