### PR TITLE
Fix # anchor links to reference.md

### DIFF
--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -49,9 +49,9 @@ Unless there are conflicts, you can even incorporate two sets of changes into th
 A version control system is a tool that keeps track of these changes for us,
 effectively creating different versions of our files. It allows us to
 decide which changes will be made to the next version (each record of these changes is called a
-[commit]({{ page.root }}/reference/#commit)), and keeps useful metadata about them. The
+[commit]({{ page.root }}/reference#commit)), and keeps useful metadata about them. The
 complete history of commits for a particular project and their metadata make up
-a [repository]({{ page.root }}/reference/#repository). Repositories can be kept in sync
+a [repository]({{ page.root }}/reference#repository). Repositories can be kept in sync
 across different computers, facilitating collaboration among different people.
 
 > ## The Long History of Version Control Systems

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -29,7 +29,7 @@ $ cd planets
 ~~~
 {: .bash}
 
-Then we tell Git to make `planets` a [repository]({{ page.root }}/reference/#repository)—a place where
+Then we tell Git to make `planets` a [repository]({{ page.root }}/reference#repository)—a place where
 Git can store versions of our files:
 
 ~~~

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -154,7 +154,7 @@ $ git commit -m "Start notes on Mars as a base"
 When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
 and stores a copy permanently inside the special `.git` directory.
-This permanent copy is called a [commit]({{ page.root }}/reference/#commit)
+This permanent copy is called a [commit]({{ page.root }}/reference)
 (or [revision]({{ page.root }}/reference/#revision)) and its short identifier is `f22b25e`.
 Your commit may have another identifier.
 
@@ -622,7 +622,7 @@ repository (`git commit`):
 > 3. "Discuss effects of Mars' climate on the Mummy"
 >
 > > ## Solution
-> > Answer 1 is not descriptive enough, and the purpose of the commit is unclear; 
+> > Answer 1 is not descriptive enough, and the purpose of the commit is unclear;
 > > and answer 2 is redundant to using "git diff" to see what changed in this commit;
 > > but answer 3 is good: short, descriptive, and imperative.
 > {: .solution}

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -155,7 +155,7 @@ When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
 and stores a copy permanently inside the special `.git` directory.
 This permanent copy is called a [commit]({{ page.root }}/reference)
-(or [revision]({{ page.root }}/reference/#revision)) and its short identifier is `f22b25e`.
+(or [revision]({{ page.root }}/reference#revision)) and its short identifier is `f22b25e`.
 Your commit may have another identifier.
 
 We use the `-m` flag (for "message")

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -154,7 +154,7 @@ $ git commit -m "Start notes on Mars as a base"
 When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
 and stores a copy permanently inside the special `.git` directory.
-This permanent copy is called a [commit]({{ page.root }}/reference)
+This permanent copy is called a [commit]({{ page.root }}/reference#commit)
 (or [revision]({{ page.root }}/reference#revision)) and its short identifier is `f22b25e`.
 Your commit may have another identifier.
 
@@ -346,7 +346,7 @@ but *not* commit some of our work drafting the conclusion
 To allow for this,
 Git has a special *staging area*
 where it keeps track of things that have been added to
-the current [changeset]({{ page.root }}/reference/#changeset)
+the current [changeset]({{ page.root }}/reference#changeset)
 but not yet committed.
 
 > ## Staging Area

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -63,13 +63,13 @@ Note that our local repository still contains our earlier work on `mars.txt`, bu
 remote repository on GitHub appears empty as it doesn't contain any files yet.
 
 The next step is to connect the two repositories.  We do this by making the
-GitHub repository a [remote]({{ page.root }}/reference/#remote) for the local repository.
+GitHub repository a [remote]({{ page.root }}/reference#remote) for the local repository.
 The home page of the repository on GitHub includes the string we need to
 identify it:
 
 ![Where to Find Repository URL on GitHub](../fig/github-find-repo-string.png)
 
-Click on the 'HTTPS' link to change the [protocol]({{ page.root }}/reference/#protocol) from
+Click on the 'HTTPS' link to change the [protocol]({{ page.root }}/reference#protocol) from
 SSH to HTTPS.
 
 > ## HTTPS vs. SSH
@@ -230,7 +230,7 @@ GitHub, though, this command would download them to our local repository.
 > Create a remote repository on GitHub.  Push the contents of your local
 > repository to the remote.  Make changes to your local repository and push
 > these changes.  Go to the repo you just created on GitHub and check the
-> [timestamps]({{ page.root }}/reference/#timestamp) of the files.  How does GitHub record
+> [timestamps]({{ page.root }}/reference#timestamp) of the files.  How does GitHub record
 > times, and why?
 >
 > > ## Solution

--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -16,8 +16,8 @@ As soon as people can work in parallel, they'll likely step on each other's
 toes.  This will even happen with a single person: if we are working on
 a piece of software on both our laptop and a server in the lab, we could make
 different changes to each copy.  Version control helps us manage these
-[conflicts]({{ page.root }}/reference/#conflicts) by giving us tools to
-[resolve]({{ page.root }}/reference/#resolve) overlapping changes.
+[conflicts]({{ page.root }}/reference#conflicts) by giving us tools to
+[resolve]({{ page.root }}/reference#resolve) overlapping changes.
 
 To see how we can resolve conflicts, we must first create one.  The file
 `mars.txt` currently looks like this in both partners' copies of our `planets`
@@ -136,7 +136,7 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 Git rejects the push because it detects that the remote repository has new updates that have not been
 incorporated into the local branch.
 What we have to do is pull the changes from GitHub,
-[merge]({{ page.root }}/reference/#merge) them into the copy we're currently working in,
+[merge]({{ page.root }}/reference#merge) them into the copy we're currently working in,
 and then push that.
 Let's start by pulling:
 

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ spend a lot of time waiting for the other to finish, but if they work
 on their own copies and email changes back and forth things will be
 lost, overwritten, or duplicated.
 
-A colleague suggests using [version control]({{ page.root }}/reference/#version-control) to
+A colleague suggests using [version control]({{ page.root }}/reference#version-control) to
 manage their work. Version control is better than mailing files back and forth:
 
 *   Nothing that is committed to version control is ever lost, unless

--- a/reference.md
+++ b/reference.md
@@ -3,7 +3,7 @@ layout: reference
 
 ---
 
-## Git Cheatsheets for Quick Reference
+## Git Cheatsheets for Quick Reference (Modified)
 
 *   A great [printable git cheatsheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf) is available in PDF from the
 [GitHub training website](https://services.github.com/resources/).
@@ -12,7 +12,7 @@ layout: reference
 *   Both resources are also available in other languages (e.g. Spanish, French, and more).
 * "[Happy Git and GitHub for the useR](http://happygitwithr.com)" is an accessible, free online book by Jenny Bryan on how to setup and use git and GitHub with specific references on the integration of git with RStudio and working with git in R.
 
-## Glossary 
+## Glossary
 
 {:auto_ids}
 changeset

--- a/reference.md
+++ b/reference.md
@@ -3,7 +3,7 @@ layout: reference
 
 ---
 
-## Git Cheatsheets for Quick Reference (Modified)
+## Git Cheatsheets for Quick Reference
 
 *   A great [printable git cheatsheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf) is available in PDF from the
 [GitHub training website](https://services.github.com/resources/).


### PR DESCRIPTION

This pull request is to fix issue [#544](https://github.com/swcarpentry/git-novice/issues/544) 

The links to the glossary items in reference.md were broken.  This is a small change to fix that.