### PR TITLE
replace bash with language-bash in class specifiers

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -27,7 +27,7 @@ Dracula sets up his new laptop:
 $ git config --global user.name "Vlad Dracula"
 $ git config --global user.email "vlad@tran.sylvan.ia"
 ~~~
-{: .bash}
+{: .language-bash}
 
 Please use your own name and email address instead of Dracula's. This user name and email will be associated with your subsequent Git activity,
 which means that any changes pushed to
@@ -56,14 +56,14 @@ in a later lesson will include this information.
 > ~~~
 > $ git config --global core.autocrlf input
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > And on Windows:
 >
 > ~~~
 > $ git config --global core.autocrlf true
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > 
 > You can read more about this issue 
 > [on this GitHub page](https://help.github.com/articles/dealing-with-line-endings/).
@@ -107,7 +107,7 @@ You can check your settings at any time:
 ~~~
 $ git config --list
 ~~~
-{: .bash}
+{: .language-bash}
 
 You can change your configuration as many times as you want: just use the
 same commands to choose another editor or update your email address.
@@ -122,7 +122,7 @@ same commands to choose another editor or update your email address.
 > $ git config --global http.proxy proxy-url
 > $ git config --global https.proxy proxy-url
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > To disable the proxy, use
 >
@@ -130,7 +130,7 @@ same commands to choose another editor or update your email address.
 > $ git config --global --unset http.proxy
 > $ git config --global --unset https.proxy
 > ~~~
-> {: .bash}
+> {: .language-bash}
 {: .callout}
 
 > ## Git Help and Manual
@@ -141,7 +141,7 @@ same commands to choose another editor or update your email address.
 > $ git config -h
 > $ git config --help
 > ~~~
-> {: .bash}
+> {: .language-bash}
 {: .callout}
 
 [git-privacy]: https://help.github.com/articles/keeping-your-email-address-private/

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -27,7 +27,7 @@ $ cd ~/Desktop
 $ mkdir planets
 $ cd planets
 ~~~
-{: .bash}
+{: .language-bash}
 
 Then we tell Git to make `planets` a [repository]({{ page.root }}/reference#repository)—a place where
 Git can store versions of our files:
@@ -35,7 +35,7 @@ Git can store versions of our files:
 ~~~
 $ git init
 ~~~
-{: .bash}
+{: .language-bash}
 
 It is important to note that `git init` will create a repository that
 includes subdirectories and their files---there is no need to create
@@ -50,7 +50,7 @@ it appears that nothing has changed:
 ~~~
 $ ls
 ~~~
-{: .bash}
+{: .language-bash}
 
 But if we add the `-a` flag to show everything,
 we can see that Git has created a hidden directory within `planets` called `.git`:
@@ -58,7 +58,7 @@ we can see that Git has created a hidden directory within `planets` called `.git
 ~~~
 $ ls -a
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 .	..	.git
@@ -76,7 +76,7 @@ by asking Git to tell us the status of our project:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 ~~~
 # On branch master
 #
@@ -105,7 +105,7 @@ wording of the output might be slightly different.
 > $ git init       # make the moons sub-directory a Git repository
 > $ ls -a          # ensure the .git sub-directory is present indicating we have created a new Git repository
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Is the `git init` command, run inside the `moons` sub-directory, required for 
 > tracking files stored in the `moons` sub-directory?
@@ -129,7 +129,7 @@ wording of the output might be slightly different.
 > > ~~~
 > > $ git status
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > ~~~
 > > fatal: Not a git repository (or any of the parent directories): .git
 > > ~~~
@@ -149,7 +149,7 @@ wording of the output might be slightly different.
 > > ~~~
 > > $ rm -rf moons/.git
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > But be careful! Running this command in the wrong directory, will remove
 > > the entire Git history of a project you might want to keep. Therefore, always check your current directory using the

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -24,7 +24,7 @@ You should be in the `planets` directory.
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 ~~~
 /home/vlad/Desktop/planets
 ~~~
@@ -35,7 +35,7 @@ If you are still in `moons`, navigate back up to `planets`
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 ~~~
 /home/vlad/Desktop/planets/moons
 ~~~
@@ -43,7 +43,7 @@ $ pwd
 ~~~
 $ cd ..
 ~~~
-{: .bash}
+{: .language-bash}
 
 Let's create a file called `mars.txt` that contains some notes
 about the Red Planet's suitability as a base.
@@ -54,7 +54,7 @@ In particular, this does not have to be the `core.editor` you set globally earli
 ~~~
 $ nano mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 Type the text below into the `mars.txt` file:
 
@@ -67,7 +67,7 @@ Cold and dry, but everything is my favorite color
 ~~~
 $ ls
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 mars.txt
@@ -77,7 +77,7 @@ mars.txt
 ~~~
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -90,7 +90,7 @@ Git tells us that it's noticed the new file:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -112,14 +112,14 @@ We can tell Git to track a file using `git add`:
 ~~~
 $ git add mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 and then check that the right thing happened:
 
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -142,7 +142,7 @@ we need to run one more command:
 ~~~
 $ git commit -m "Start notes on Mars as a base"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master (root-commit) f22b25e] Start notes on Mars as a base
@@ -173,7 +173,7 @@ If we run `git status` now:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -188,7 +188,7 @@ we can ask Git to show us the project's history using `git log`:
 ~~~
 $ git log
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
@@ -225,7 +225,7 @@ you may use a different editor, and don't need to `cat`.)
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -239,7 +239,7 @@ it tells us that a file it already knows about has been modified:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -267,7 +267,7 @@ of the file and the most recently saved version:
 ~~~
 $ git diff
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/mars.txt b/mars.txt
@@ -302,7 +302,7 @@ After reviewing our change, it's time to commit it:
 $ git commit -m "Add concerns about effects of Mars' moons on Wolfman"
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -324,7 +324,7 @@ Let's fix that:
 $ git add mars.txt
 $ git commit -m "Add concerns about effects of Mars' moons on Wolfman"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 34961b1] Add concerns about effects of Mars' moons on Wolfman
@@ -381,7 +381,7 @@ we'll add another line to the file:
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -393,7 +393,7 @@ But the Mummy will appreciate the lack of humidity
 ~~~
 $ git diff
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/mars.txt b/mars.txt
@@ -417,7 +417,7 @@ and see what `git diff` reports:
 $ git add mars.txt
 $ git diff
 ~~~
-{: .bash}
+{: .language-bash}
 
 There is no output:
 as far as Git can tell,
@@ -429,7 +429,7 @@ if we do this:
 ~~~
 $ git diff --staged
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/mars.txt b/mars.txt
@@ -451,7 +451,7 @@ Let's save our changes:
 ~~~
 $ git commit -m "Discuss concerns about Mars' climate for Mummy"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 005937f] Discuss concerns about Mars' climate for Mummy
@@ -464,7 +464,7 @@ check our status:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -477,7 +477,7 @@ and look at the history of what we've done so far:
 ~~~
 $ git log
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
@@ -533,7 +533,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > $ git log -1
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > ~~~
 > commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
@@ -550,7 +550,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > $ git log --oneline
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > * 005937f Discuss concerns about Mars' climate for Mummy
 > * 34961b1 Add concerns about effects of Mars' moons on Wolfman
@@ -564,7 +564,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > $ git log --oneline --graph --all --decorate
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > * 005937f Discuss concerns about Mars' climate for Mummy (HEAD, master)
 > * 34961b1 Add concerns about effects of Mars' moons on Wolfman
@@ -586,7 +586,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 >    $ git add directory
 >    $ git status
 >    ~~~
->    {: .bash}
+>    {: .language-bash}
 >
 >    Note, our newly created empty directory `directory` does not appear in
 >    the list of untracked files even if we explicitly add it (_via_ `git add`) to our
@@ -601,7 +601,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 >    ~~~
 >    git add <directory-with-files>
 >    ~~~
->    {: .bash}
+>    {: .language-bash}
 >
 {: .callout}
 
@@ -636,21 +636,21 @@ repository (`git commit`):
 > 1. ~~~
 >    $ git commit -m "my recent changes"
 >    ~~~
->    {: .bash}
+>    {: .language-bash}
 > 2. ~~~
 >    $ git init myfile.txt
 >    $ git commit -m "my recent changes"
 >    ~~~
->    {: .bash}
+>    {: .language-bash}
 > 3. ~~~
 >    $ git add myfile.txt
 >    $ git commit -m "my recent changes"
 >    ~~~
->    {: .bash}
+>    {: .language-bash}
 > 4. ~~~
 >    $ git commit -m myfile.txt "my recent changes"
 >    ~~~
->    {: .bash}
+>    {: .language-bash}
 >
 > > ## Solution
 > >
@@ -680,7 +680,7 @@ repository (`git commit`):
 > > $ nano mars.txt
 > > $ cat mars.txt
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > ~~~
 > > Maybe I should start with a base on Venus.
 > > ~~~
@@ -689,7 +689,7 @@ repository (`git commit`):
 > > $ nano venus.txt
 > > $ cat venus.txt
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > ~~~
 > > Venus is a nice planet and I definitely should consider it as a base.
 > > ~~~
@@ -699,18 +699,18 @@ repository (`git commit`):
 > > ~~~
 > > $ git add mars.txt venus.txt
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > Or with multiple commands:
 > > ~~~
 > > $ git add mars.txt
 > > $ git add venus.txt
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > Now the files are ready to commit. You can check that using `git status`. If you are ready to commit use:
 > > ~~~
 > > $ git commit -m "Write plans to start a base on Venus"
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > ~~~
 > > [master cc127c2]
 > >  Write plans to start a base on Venus
@@ -737,7 +737,7 @@ repository (`git commit`):
 > > ~~~
 > > $ cd ..
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Create a new folder called `bio` and 'move' into it:
 > >
@@ -745,14 +745,14 @@ repository (`git commit`):
 > > $ mkdir bio
 > > $ cd bio
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Initialise git:
 > >
 > > ~~~
 > > $ git init
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Create your biography file `me.txt` using `nano` or another text editor.
 > > Once in place, add and commit it to the repository:
@@ -761,7 +761,7 @@ repository (`git commit`):
 > > $ git add me.txt
 > > $ git commit -m'Adding biography file'
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Modify the file as described (modify one line, add a fourth line).
 > > To display the differences
@@ -770,7 +770,7 @@ repository (`git commit`):
 > > ~~~
 > > $ git diff me.txt
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > {: .solution}
 {: .challenge}
@@ -785,14 +785,14 @@ repository (`git commit`):
 > ~~~
 > $ git log --format=full
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > When committing you can name someone else as the author:
 >
 > ~~~
 > $ git commit --author="Vlad Dracula <vlad@tran.sylvan.ia>"
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Create a new repository and create two commits: one without the
 > `--author` option and one by naming a colleague of yours as the
@@ -805,7 +805,7 @@ repository (`git commit`):
 > > $ git add me.txt
 > > $ git commit -m "Update Vlad's bio." --author="Frank N. Stein <franky@monster.com>"
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > ~~~
 > > [master 4162a51] Update Vlad's bio.
 > > Author: Frank N. Stein <franky@monster.com>

--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -28,7 +28,7 @@ let's make a change to `mars.txt`.
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -43,7 +43,7 @@ Now, let's see what we get.
 ~~~
 $ git diff HEAD mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/mars.txt b/mars.txt
@@ -67,7 +67,7 @@ to refer to the commit one before `HEAD`.
 ~~~
 $ git diff HEAD~1 mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 If we want to see the differences between older commits we can use `git diff`
 again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to them:
@@ -76,7 +76,7 @@ again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to them:
 ~~~
 $ git diff HEAD~2 mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/mars.txt b/mars.txt
@@ -96,7 +96,7 @@ We could also use `git show` which shows us what changes we made at an older com
 ~~~
 $ git show HEAD~2 mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 commit 34961b159c27df3b475cfe4415d94a6d1fcd064d
@@ -137,7 +137,7 @@ so let's try this:
 ~~~
 $ git diff f22b25e3233b4645dabd0d81e651fe074bd8e73b mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/mars.txt b/mars.txt
@@ -159,7 +159,7 @@ so Git lets us use just the first few characters:
 ~~~
 $ git diff f22b25e mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/mars.txt b/mars.txt
@@ -183,7 +183,7 @@ Let's suppose we accidentally overwrite our file:
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 We will need to manufacture our own oxygen
@@ -196,7 +196,7 @@ but those changes haven't been staged:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -217,7 +217,7 @@ by using `git checkout`:
 $ git checkout HEAD mars.txt
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -237,12 +237,12 @@ we can use a commit identifier instead:
 ~~~
 $ git checkout f22b25e mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -252,7 +252,7 @@ Cold and dry, but everything is my favorite color
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # On branch master
@@ -275,7 +275,7 @@ by using `git checkout`:
 ~~~
 $ git checkout HEAD mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 > ## Don't Lose Your HEAD
 >
@@ -284,7 +284,7 @@ $ git checkout HEAD mars.txt
 > ~~~
 > $ git checkout f22b25e mars.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > to revert `mars.txt` to its state after the commit `f22b25e`. But be careful! 
 > The command `checkout` has other important functionalities and Git will misunderstand
@@ -294,7 +294,7 @@ $ git checkout HEAD mars.txt
 > ~~~
 > $ git checkout f22b25e
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > Note: checking out 'f22b25e'.
 >
@@ -339,7 +339,7 @@ here's how Git works in cartoon form:
 > ~~~
 > (use "git checkout -- <file>..." to discard changes in working directory)
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > As it says,
 > `git checkout` without a version identifier restores files to the state saved in `HEAD`.
@@ -415,7 +415,7 @@ moving backward and forward in time becomes much easier.
 > $ git checkout HEAD venus.txt
 > $ cat venus.txt #this will print the contents of venus.txt to the screen
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > 1. ~~~
 >    Venus is too hot to be suitable as a base
@@ -478,7 +478,7 @@ moving backward and forward in time becomes much easier.
 > ~~~
 > $ git log mars.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Unfortunately some of these commit messages are very ambiguous e.g. `update files`.
 > How can you search through these files?
@@ -489,7 +489,7 @@ moving backward and forward in time becomes much easier.
 > ~~~
 > $ git log --patch mars.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > You should get a long list of output, and you should be able to see both commit messages and the difference between each commit.
 >
@@ -498,5 +498,5 @@ moving backward and forward in time becomes much easier.
 > ~~~
 > $ git log --patch HEAD~3 *.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 {: .challenge}

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -20,14 +20,14 @@ Let's create a few dummy files:
 $ mkdir results
 $ touch a.dat b.dat c.dat results/a.out results/b.out
 ~~~
-{: .bash}
+{: .language-bash}
 
 and see what Git says:
 
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -53,7 +53,7 @@ We do this by creating a file in the root directory of our project called `.giti
 $ nano .gitignore
 $ cat .gitignore
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 *.dat
@@ -72,7 +72,7 @@ the output of `git status` is much cleaner:
 ~~~
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -95,7 +95,7 @@ $ git add .gitignore
 $ git commit -m "Ignore data files and the results folder."
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # On branch master
@@ -108,7 +108,7 @@ As a bonus, using `.gitignore` helps us avoid accidentally adding to the reposit
 ~~~
 $ git add a.dat
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 The following paths are ignored by one of your .gitignore files:
@@ -125,7 +125,7 @@ We can also always see the status of ignored files if we want:
 ~~~
 $ git status --ignored
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -149,7 +149,7 @@ nothing to commit, working directory clean
 > results/data
 > results/plots
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > How would you ignore only `results/plots` and not `results/data`?
 >
@@ -205,7 +205,7 @@ nothing to commit, working directory clean
 > results/data/position/gps/info.txt
 > results/plots
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > What's the shortest `.gitignore` rule you could write to ignore all `.data`
 > files in `result/data/position/gps`? Do not ignore the `info.txt`.
@@ -225,7 +225,7 @@ nothing to commit, working directory clean
 > *.data
 > !*.data
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > What will be the result?
 >

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -47,7 +47,7 @@ $ mkdir planets
 $ cd planets
 $ git init
 ~~~
-{: .bash}
+{: .language-bash}
 
 If you remember back to the earlier [lesson](./04-changes.html) where we added and
 commited our earlier work on `mars.txt`, we had a diagram of the local repository
@@ -91,7 +91,7 @@ this command:
 ~~~
 $ git remote add origin https://github.com/vlad/planets.git
 ~~~
-{: .bash}
+{: .language-bash}
 
 Make sure to use the URL for your repository rather than Vlad's: the only
 difference should be your username instead of `vlad`.
@@ -101,7 +101,7 @@ We can check that the command has worked by running `git remote -v`:
 ~~~
 $ git remote -v
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 origin   https://github.com/vlad/planets.git (push)
@@ -118,7 +118,7 @@ our local repository to the repository on GitHub:
 ~~~
 $ git push origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Counting objects: 9, done.
@@ -142,7 +142,7 @@ Branch master set up to track remote branch master from origin.
 > $ git config --global http.proxy http://user:password@proxy.url
 > $ git config --global https.proxy http://user:password@proxy.url
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > When you connect to another network that doesn't use a proxy, you will need to
 > tell Git to disable the proxy using:
@@ -151,7 +151,7 @@ Branch master set up to track remote branch master from origin.
 > $ git config --global --unset http.proxy
 > $ git config --global --unset https.proxy
 > ~~~
-> {: .bash}
+> {: .language-bash}
 {: .callout}
 
 > ## Password Managers
@@ -165,7 +165,7 @@ Branch master set up to track remote branch master from origin.
 > ~~~
 > $ unset SSH_ASKPASS
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > in the terminal, before you run `git push`.  Despite the name, [git uses
 > `SSH_ASKPASS` for all credential
@@ -195,7 +195,7 @@ We can pull changes from the remote repository to the local one as well:
 ~~~
 $ git pull origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 From https://github.com/vlad/planets
@@ -257,7 +257,7 @@ GitHub, though, this command would download them to our local repository.
 > ~~~
 > git remote add broken https://github.com/this/url/is/invalid
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Do you get an error when adding the remote? Can you think of a
 > command that would make it obvious that your remote URL was not
@@ -281,7 +281,7 @@ GitHub, though, this command would download them to our local repository.
 > > ~~~
 > > $ git pull origin master
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > 
 > > ~~~
 > > From https://github.com/vlad/planets
@@ -295,7 +295,7 @@ GitHub, though, this command would download them to our local repository.
 > > ~~~
 > > $ git pull --allow-unrelated-histories origin master
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > > 
 > > ~~~
 > > From https://github.com/vlad/planets

--- a/_episodes/08-collab.md
+++ b/_episodes/08-collab.md
@@ -42,7 +42,7 @@ her `Desktop` folder, the Collaborator enters:
 ~~~
 $ git clone https://github.com/vlad/planets.git ~/Desktop/vlad-planets
 ~~~
-{: .bash}
+{: .language-bash}
 
 Replace 'vlad' with the Owner's username.
 
@@ -56,7 +56,7 @@ $ cd ~/Desktop/vlad-planets
 $ nano pluto.txt
 $ cat pluto.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 It is so a planet!
@@ -67,7 +67,7 @@ It is so a planet!
 $ git add pluto.txt
 $ git commit -m "Add notes about Pluto"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
  1 file changed, 1 insertion(+)
@@ -80,7 +80,7 @@ Then push the change to the *Owner's repository* on GitHub:
 ~~~
 $ git push origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Counting objects: 4, done.
@@ -106,7 +106,7 @@ To download the Collaborator's changes from GitHub, the Owner now enters:
 ~~~
 $ git pull origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 remote: Counting objects: 4, done.

--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -26,7 +26,7 @@ repository:
 ~~~
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -41,7 +41,7 @@ Let's add a line to one partner's copy only:
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -57,7 +57,7 @@ and then push the change to GitHub:
 $ git add mars.txt
 $ git commit -m "Add a line in our home copy"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 5ae9631] Add a line in our home copy
@@ -68,7 +68,7 @@ $ git commit -m "Add a line in our home copy"
 ~~~
 $ git push origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Counting objects: 5, done.
@@ -89,7 +89,7 @@ make a different change to their copy
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -105,7 +105,7 @@ We can commit the change locally:
 $ git add mars.txt
 $ git commit -m "Add a line in my copy"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 07ebc69] Add a line in my copy
@@ -118,7 +118,7 @@ but Git won't let us push it to GitHub:
 ~~~
 $ git push origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 To https://github.com/vlad/planets.git
@@ -143,7 +143,7 @@ Let's start by pulling:
 ~~~
 $ git pull origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 remote: Counting objects: 5, done.
@@ -168,7 +168,7 @@ in the affected file:
 ~~~
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -198,7 +198,7 @@ Let's replace both so that the file looks like this:
 ~~~
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -216,7 +216,7 @@ and then commit:
 $ git add mars.txt
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -233,7 +233,7 @@ Changes to be committed:
 ~~~
 $ git commit -m "Merge changes from GitHub"
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [master 2abf2b1] Merge changes from GitHub
@@ -245,7 +245,7 @@ Now we can push our changes to GitHub:
 ~~~
 $ git push origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Counting objects: 10, done.
@@ -265,7 +265,7 @@ when the collaborator who made the first change pulls again:
 ~~~
 $ git pull origin master
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 remote: Counting objects: 10, done.
@@ -286,7 +286,7 @@ We get the merged file:
 ~~~
 $ cat mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Cold and dry, but everything is my favorite color
@@ -346,7 +346,7 @@ Conflicts can also be minimized with project management strategies:
 > > $ head --bytes 1024 /dev/urandom > mars.jpg
 > > $ ls -lh mars.jpg
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ~~~
 > > -rw-r--r-- 1 vlad 57095 1.0K Mar  8 20:24 mars.jpg
@@ -362,7 +362,7 @@ Conflicts can also be minimized with project management strategies:
 > > $ git add mars.jpg
 > > $ git commit -m "Add picture of Martian surface"
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ~~~
 > > [master 8e4115c] Add picture of Martian surface
@@ -378,7 +378,7 @@ Conflicts can also be minimized with project management strategies:
 > > ~~~
 > > $ git push origin master
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ~~~
 > > To https://github.com/vlad/planets.git
@@ -397,7 +397,7 @@ Conflicts can also be minimized with project management strategies:
 > > ~~~
 > > $ git pull origin master
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > When there is a conflict on an image or other binary file, git prints
 > > a message like this:
@@ -439,7 +439,7 @@ Conflicts can also be minimized with project management strategies:
 > > $ git add mars.jpg
 > > $ git commit -m "Use image of surface instead of sky"
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ~~~
 > > [master 21032c3] Use image of surface instead of sky
@@ -454,7 +454,7 @@ Conflicts can also be minimized with project management strategies:
 > > $ git add mars.jpg
 > > $ git commit -m "Use image of sky instead of surface"
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ~~~
 > > [master da21b34] Use image of sky instead of surface
@@ -472,7 +472,7 @@ Conflicts can also be minimized with project management strategies:
 > > $ git checkout 439dc8c0 mars.jpg
 > > $ mv mars.jpg mars-sky.jpg
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Then, remove the old `mars.jpg` and add the two new files:
 > >
@@ -482,7 +482,7 @@ Conflicts can also be minimized with project management strategies:
 > > $ git add mars-sky.jpg
 > > $ git commit -m "Use two images: surface and sky"
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ~~~
 > > [master 94ae08c] Use two images: surface and sky

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -21,7 +21,7 @@ in a plain text file called `.gitconfig`.
 ~~~
 $ cat ~/.gitconfig
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 [user]
@@ -45,7 +45,7 @@ The available options are described in the manual:
 ~~~
 $ git config --help
 ~~~
-{: .bash}
+{: .language-bash}
 
 In particular, you might find it useful to add aliases.
 These are like shortcuts for longer git commands.
@@ -55,21 +55,21 @@ you could run the command:
 ~~~
 $ git config --global alias.co checkout
 ~~~
-{: .bash}
+{: .language-bash}
 
 Now if we return to the example from [Exploring History]({{ page.root }}/05-history/) where we ran:
 
 ~~~
 $ git checkout f22b25e mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 we could now instead type:
 
 ~~~
 $ git co f22b25e mars.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ## Styling Git's Log
 
@@ -88,7 +88,7 @@ $ git config --global log.abbrevCommit true
 $ git config --global format.pretty oneline
 $ git lg
 ~~~
-{: .bash}
+{: .language-bash}
 
 If you don't like the effects,
 you can undo them with:
@@ -98,7 +98,7 @@ $ git config --global --unset alias.lg
 $ git config --global --unset log.abbrevCommit
 $ git config --global --unset format.pretty
 ~~~
-{: .bash}
+{: .language-bash}
 
 > ## Undoing Git Configuration Changes
 >
@@ -146,7 +146,7 @@ Create a new directory and go into it:
 $ mkdir planets-nontext
 $ cd planets-nontext
 ~~~
-{: .bash}
+{: .language-bash}
 
 Use a program such as Microsoft Word or LibreOffice Writer to create a new document.
 Enter the same text that we began with before:
@@ -164,7 +164,7 @@ $ git init
 $ git add mars.doc
 $ git commit -m "Starting to think about Mars"
 ~~~
-{: .bash}
+{: .language-bash}
 
 Then make the same changes to `mars.doc` that we (or Vlad) previously made to `mars.txt`.
 
@@ -180,7 +180,7 @@ Now see what Git thinks of your changes:
 ~~~
 $ git diff
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 diff --git a/mars.doc b/mars.doc
@@ -230,7 +230,7 @@ Create a new file for the planet Nibiru:
 ~~~
 $ echo "This is another name for fake planet X" > nibiru.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 Now add to the repository like you have learned earlier:
 
@@ -239,7 +239,7 @@ $ git add nibiru.txt
 $ git commit -m 'adding info on nibiru'
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -254,7 +254,7 @@ it from the disk and let Git know about it:
 $ git rm nibiru.txt
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -274,7 +274,7 @@ have the file, if you were to retrieve that specific commit.
 ~~~
 $ git commit -m 'Removing info on Nibiru.  It is not a real planet!'
 ~~~
-{: .bash}
+{: .language-bash}
 
 ## Removing a File with Unix
 
@@ -288,7 +288,7 @@ $ echo "This is another name for fake planet X" > nibiru.txt
 $ git add nibiru.txt
 $ git commit -m 'adding nibiru again'
 ~~~
-{: .bash}
+{: .language-bash}
 
 Now we remove the file with Unix `rm`:
 
@@ -296,7 +296,7 @@ Now we remove the file with Unix `rm`:
 $ rm nibiru.txt
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -319,7 +319,7 @@ before.
 $ git rm nibiru.txt
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -337,7 +337,7 @@ committed.
 ~~~
 $ git commit -m 'Removing info on Nibiru, again!'
 ~~~
-{: .bash}
+{: .language-bash}
 
 ## Renaming a File
 
@@ -348,7 +348,7 @@ Create a file for the planet Krypton:
 ~~~
 $ echo "Superman's home planet" > krypton.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 Add it to the repository:
 
@@ -356,7 +356,7 @@ Add it to the repository:
 $ git add krypton.txt
 $ git commit -m 'Adding planet Krypton'
 ~~~
-{: .bash}
+{: .language-bash}
 
 We all know that Superman moved to Earth.  Not that he had much
 choice.  Now his home planet is Earth.
@@ -367,7 +367,7 @@ Rename the file `krypton.txt` to `earth.txt` with Git:
 $ git mv krypton.txt earth.txt
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # On branch master
@@ -383,7 +383,7 @@ The final step is commit our change to the repository:
 ~~~
 $ git commit -m 'Superman's home is now Earth'
 ~~~
-{: .bash}
+{: .language-bash}
 
 ## Renaming a File with Unix
 
@@ -398,7 +398,7 @@ $ echo "Superman's home planet" > krypton.txt
 $ git add krypton.txt
 $ git commit -m 'Adding planet Krypton again.'
 ~~~
-{: .bash}
+{: .language-bash}
 
 Let us rename the file and see what Git can figured out by itself:
 
@@ -406,7 +406,7 @@ Let us rename the file and see what Git can figured out by itself:
 $ mv krypton.txt earth.txt
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -434,7 +434,7 @@ Add those changes to the staging area:
 $ git add krypton.txt earth.txt
 $ git status
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 On branch master
@@ -454,5 +454,5 @@ The final step, as before, is to commit our change to the repository:
 ~~~
 $ git commit -m 'Superman's home is Earth, told you before.'
 ~~~
-{: .bash}
+{: .language-bash}
 	

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -128,7 +128,7 @@ working in teams or not, because it is
     $ mv .git temp_git
     $ rm -rf  temp_git
     ~~~
-    {: .bash}
+    {: .language-bash}
 
     The challenge suggests that it is a bad idea to create a Git repo inside another repo.
     For more discussion on this topic, please see [this issue][repos-in-repos].
@@ -212,7 +212,7 @@ particular set of files in `.gitignore`.
     ~~~
     $ git clone https://github.com/vlad/planets.git planets-at-work
     ~~~
-    {: .bash}
+    {: .language-bash}
 
 *   It's very common that learners mistype the remote alias or the remote URL
     when adding a remote, so they cannot `push`. You can diagnose this with
@@ -230,7 +230,7 @@ particular set of files in `.gitignore`.
     ~~~
     $ git clone https://github.com/vlad/planets.git vlad-planet
     ~~~
-    {: .bash}
+    {: .language-bash}
 
 *   The most common mistake is that learners `push` before `pull`ing. If they
     `pull` afterward, they may get a conflict.

--- a/setup.md
+++ b/setup.md
@@ -12,6 +12,6 @@ We'll do our work in the `Desktop` folder so make sure you change your working d
 $ cd
 $ cd Desktop
 ~~~
-{: .bash}
+{: .language-bash}
 
 [workshop-setup]: https://carpentries.github.io/workshop-template/#git


### PR DESCRIPTION
`bash` code blocks are not properly syntax-highlighted, since the specifier is `.language-bash`, not `.bash`. This typographical error also triggers errors in `make lesson-check`. This PR resolves both issues.