### PR TITLE
Changed the relative link to a full one to point the URL to github.co…

### DIFF
--- a/_episodes/13-hosting.md
+++ b/_episodes/13-hosting.md
@@ -42,7 +42,7 @@ communities already using the same service.
 
 As an example, Software Carpentry [is on
 GitHub]({{ swc_github }}) where you can find the [source for this
-page]({{page.root}}/_episodes/13-hosting.md).
+page](https://github.com/swcarpentry/git-novice/blob/gh-pages/_episodes/13-hosting.md).
 Anyone with a GitHub account can suggest changes to this text.
 
 GitHub repositories can also be assigned DOIs, [by connecting its releases to


### PR DESCRIPTION
…m Fixes #551
Replaced {{page.root}}/_episodes/13-hosting.md with https://swcarpentry.github.io/git-novice/_episodes/13-hosting.md. So the link will point to github.com (not github pages)