### PR TITLE
Wording on core.autocrlf explanation

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -44,7 +44,10 @@ in a later lesson will include this information.
 > Different operating systems use different character(s) to represent the end of a line.
 > (You may also hear these referred to as newlines or line breaks.)
 > Because Git uses these characters to compare files,
-> it may cause unexpected issues when editing a file on different machines.
+> it may cause unexpected issues when editing a file on different machines. 
+> Don't hesitate to read more about this issue on your own time
+> [on this GitHub page](https://help.github.com/articles/dealing-with-line-endings/).
+{: .callout}
 >
 > You can change the way Git recognizes and encodes line endings
 > using the `core.autocrlf` command to `git config`.
@@ -64,9 +67,6 @@ in a later lesson will include this information.
 > ~~~
 > {: .language-bash}
 > 
-> You can read more about this issue 
-> [on this GitHub page](https://help.github.com/articles/dealing-with-line-endings/).
-{: .callout}
 
 For these lessons, we will be interacting with [GitHub](https://github.com/) and so the email address used should be the same as the one used when setting up your GitHub account. If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private][git-privacy]. 
 If you elect to use a private email address with GitHub, then use that same email address for the `user.email` value, e.g. `username@users.noreply.github.com` replacing `username` with your GitHub one. You can change the email address later on by using the `git config` command again.

--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -45,7 +45,7 @@ in a later lesson will include this information.
 > (You may also hear these referred to as newlines or line breaks.)
 > Because Git uses these characters to compare files,
 > it may cause unexpected issues when editing a file on different machines. 
-> Don't hesitate to read more about this issue on your own time
+> Though it is beyond the scope of this lesson, you can read more about this issue on
 > [on this GitHub page](https://help.github.com/articles/dealing-with-line-endings/).
 {: .callout}
 >

--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -41,8 +41,7 @@ in a later lesson will include this information.
 >
 > As with other keys, when you hit <kbd>Return</kbd> on your keyboard,
 > your computer encodes this input as a character.
-> For reasons that are long to explain, different operating systems
-> use different character(s) to represent the end of a line.
+> Different operating systems use different character(s) to represent the end of a line.
 > (You may also hear these referred to as newlines or line breaks.)
 > Because Git uses these characters to compare files,
 > it may cause unexpected issues when editing a file on different machines.


### PR DESCRIPTION
"For reasons that are long to explain," could be seen as discouraging language by a novice git user. We provide them with the link to the Github page where they can learn more about line endings. I think even if they are curious to learn, they might be reluctant to open up the Github page if they worry how long it might take. 

