### PR TITLE
Fix output of git status after checking out file

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -255,16 +255,12 @@ $ git status
 {: .language-bash}
 
 ~~~
-# On branch master
+On branch master
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
-# Changes not staged for commit:
-#   (use "git add <file>..." to update what will be committed)
-#   (use "git checkout -- <file>..." to discard changes in working directory)
-#
-#	modified:   mars.txt
-#
-no changes added to commit (use "git add" and/or "git commit -a")
+
+	modified:   mars.txt
+
 ~~~
 {: .output}
 

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -446,8 +446,8 @@ Changes to be committed:
 ~~~
 {: .output}
 
-Notice how Git has now figure out that the `krypton.txt` has not
-disappeared it has simply been renamed.
+Notice how Git has now figured out that the `krypton.txt` has not
+disappeared - it has simply been renamed.
 
 The final step, as before, is to commit our change to the repository:
 


### PR DESCRIPTION
I have noticed that the output of `git status` after a file had been checked out from a previous commit is wrong, so here's a fix. The text already correctly stated that the file would be staged.