### PR TITLE
Added a link of resources in references

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -11,6 +11,7 @@ layout: reference
     about the relationships between workspace, staging area, local repository, upstream repository, and the commands associated with each (with explanations).
 *   Both resources are also available in other languages (e.g. Spanish, French, and more).
 * "[Happy Git and GitHub for the useR](http://happygitwithr.com)" is an accessible, free online book by Jenny Bryan on how to setup and use git and GitHub with specific references on the integration of git with RStudio and working with git in R.
+* [Open Scientific Code using Git and GitHub](https://open-source-for-researchers.github.io/open-source-workshop/) - A collection of explanations and short practical exercises to help researchers learn more about version control and open source software.
 
 ## Glossary
 


### PR DESCRIPTION
Added a link to Open Scientific Code using Git and GitHub, a collection of explanations and short practical exercises to help researchers learn more about version control and open source software to references.md. A good resource for people who want more practice with Git and Github.


