### PR TITLE
Add software-specific citation file example

### DIFF
--- a/_episodes/12-citation.md
+++ b/_episodes/12-citation.md
@@ -1,6 +1,6 @@
 ---
 title: Citation
-teaching: 2
+teaching: 3
 exercises: 0
 questions:
 - "How can I make my work easier to cite?"
@@ -48,10 +48,27 @@ July 2013.
 More detailed advice, and other ways to make your code citable can be found
 [at the Software Sustainability Institute blog](https://www.software.ac.uk/how-cite-and-describe-software) and in:
 
->  Smith AM, Katz DS, Niemeyer KE, FORCE11 Software Citation Working Group. 
+>  Smith AM, Katz DS, Niemeyer KE, FORCE11 Software Citation Working Group.
 >  (2016) Software citation principles. [PeerJ Computer Science 2:e86](https://peerj.com/articles/cs-86/) https://doi.org/10.7717/peerj-cs.86
- 
-There is also an [`@software{…`](https://www.google.de/search?q=git+citation+%22%40software%7B%22) 
+
+There is also an [`@software{…`](https://www.google.de/search?q=git+citation+%22%40software%7B%22)
 [BibTeX](https://www.ctan.org/pkg/bibtex) entry type in case
 no "umbrella" citation like a paper or book exists for the project you want to
 make citable.
+
+If your project is a software project, include a file called `CITATION.cff` in the
+[Citation File Format (CFF)](https://citation-file-format.github.io/) in your project.
+
+A basic example that you can copy, paste and edit looks like this:
+
+~~~
+cff-version: 1.0.3
+message: If you use this software, please cite it as below.
+authors:
+  - family-names: Qin Korhonen
+    given-names: Kim
+title: Science Toolkit
+version: 0.9.7
+doi: 10.5281/zenodo.1234
+date-released: 2017-12-18
+~~~


### PR DESCRIPTION
Good practices for providing software citation metadata are moving beyond the provision of plain-text CITATION files (> machine-readability). The one commit in this PR contains more info. It adds a simple example for a CITATION.cff file for providing software citation metadata.