### PR TITLE
Slight wording change to episode 01 to clarify the meaning of a git 'conflict'

### DIFF
--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -42,7 +42,7 @@ sets of changes on the same document.
 
 ![Different Versions Can be Saved](../fig/versions.svg)
 
-Unless there are conflicts, you can even incorporate two sets of changes into the same base document.
+Unless multiple users make changes to the same section of the document - a conflict - you can incorporate two sets of changes into the same base document.
 
 ![Multiple Versions Can be Merged](../fig/merge.svg)
 


### PR DESCRIPTION
PR to address issue #567 . Changes the wording in the first lession to include an explanation of what a conflict might be, using the writing analogy to be consistent with the rest of the lesson.