### PR TITLE
Change pager keys to lowercase

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -515,12 +515,12 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > When this "pager" is called, you will notice that the last line in your
 > screen is a `:`, instead of your usual prompt.
 >
-> *   To get out of the pager, press <kbd>Q</kbd>.
+> *   To get out of the pager, press <kbd>q</kbd>.
 > *   To move to the next page, press <kbd>Spacebar</kbd>.
 > *   To search for `some_word` in all pages,
 >     press <kbd>/</kbd>
 >     and type `some_word`.
->     Navigate through matches pressing <kbd>N</kbd>.
+>     Navigate through matches pressing <kbd>n</kbd>.
 {: .callout}
 
 > ## Limit Log Size


### PR DESCRIPTION
Change N to n:
N searches in reverse when using less, this brings up the confusing message that no matches are found (unless the user has already previously pressed n). The key for searching forward is lowercase n.
Change Q to q:
Both Q and q are valid choices for exiting the pager. Lowercase q requires fewer keystrokes, and therefore is (arguably) simpler and a better habit to form (given a choice).
