### PR TITLE
Revert "Change pager keys to lowercase"

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -515,12 +515,12 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > When this "pager" is called, you will notice that the last line in your
 > screen is a `:`, instead of your usual prompt.
 >
-> *   To get out of the pager, press <kbd>q</kbd>.
+> *   To get out of the pager, press <kbd>Q</kbd>.
 > *   To move to the next page, press <kbd>Spacebar</kbd>.
 > *   To search for `some_word` in all pages,
 >     press <kbd>/</kbd>
 >     and type `some_word`.
->     Navigate through matches pressing <kbd>n</kbd>.
+>     Navigate through matches pressing <kbd>N</kbd>.
 {: .callout}
 
 > ## Limit Log Size


### PR DESCRIPTION
Reverts swcarpentry/git-novice#570!

Thanks very much to @M4rkD for the pull request but changes of this kind need to be discussed with the maintainers because impact our style guide, see https://carpentries.github.io/lesson-example/06-style-guide/index.html. On our guide, we have

```
to delete the cell press <kbd>D</kbd>
```

We expect that users press the key "D" on their keyboard and not Shift + "D". The reasoning for this is to make the content of the lessons, in this case, the key that users need to search in their keyboard closer to what they will find. This is why we use "Ctrl" and not "CTRL".

@swcarpentry/git-maintainers Could please merge this and add comments to https://github.com/carpentries/lesson-example/issues/236. Thanks very much.