### PR TITLE
Episode 4: make Directories example more explicit

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -581,14 +581,14 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 >    Try it for yourself:
 >
 >    ~~~
->    $ mkdir directory
+>    $ mkdir spaceships
 >    $ git status
->    $ git add directory
+>    $ git add spaceships
 >    $ git status
 >    ~~~
 >    {: .language-bash}
 >
->    Note, our newly created empty directory `directory` does not appear in
+>    Note, our newly created empty directory `spaceships` does not appear in
 >    the list of untracked files even if we explicitly add it (_via_ `git add`) to our
 >    repository. This is the reason why you will sometimes see `.gitkeep` files
 >    in otherwise empty directories. Unlike `.gitignore`, these files are not special
@@ -600,6 +600,16 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 >
 >    ~~~
 >    git add <directory-with-files>
+>    ~~~
+>    {: .language-bash}
+>
+>    Try it for yourself:
+>
+>    ~~~
+>    $ touch spaceships/apollo-11 spaceships/sputnik-1
+>    $ git status
+>    $ git add spaceships
+>    $ git status
 >    ~~~
 >    {: .language-bash}
 >


### PR DESCRIPTION
Directories are an important concept in git, and this exercise is a useful one, but it can be improved.

This commit improves the example in two ways:
* Firstly, we now use the name "spaceships" for the directory instead of simply "directory"; this makes it clear to learners which part of the command is syntax and which is a name.
* Secondly, we add an extra code block that explicitly creates files and adds a directory.  The final `git status` command shows the user that the two new files have been added.

This was done as a contribution for Instructor Training Checkout.