### PR TITLE
More detail about remotes in episodes 7 & 8

### DIFF
--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -113,7 +113,8 @@ origin   https://github.com/vlad/planets.git (fetch)
 ~~~
 {: .output}
 
-We'll discuss remotes in more detail in the next episode, while talking about collaboration.
+We'll discuss remotes in more detail in the next episode, while 
+talking about how they might be used for collaboration.
 
 Once the remote is set up, this command will push the changes from
 our local repository to the repository on GitHub:

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -113,7 +113,7 @@ origin   https://github.com/vlad/planets.git (fetch)
 ~~~
 {: .output}
 
-We'll discuss remotes in more detail in the next episode.
+We'll discuss remotes in more detail in the next episode, while talking about collaboration.
 
 Once the remote is set up, this command will push the changes from
 our local repository to the repository on GitHub:

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -97,8 +97,8 @@ Make sure to use the URL for your repository rather than Vlad's: the only
 difference should be your username instead of `vlad`.
 
 `origin` is a local name used to refer to the remote repository. It could be called
-anything else, but `origin` is a convention that is often used by default in git
-and github. We'll discuss remotes in more detail in the next episode.
+anything, but `origin` is a convention that is often used by default in git
+and github, so it's helpful to stick with this unless there's a reason not to.
 
 We can check that the command has worked by running `git remote -v`:
 
@@ -112,6 +112,8 @@ origin   https://github.com/vlad/planets.git (push)
 origin   https://github.com/vlad/planets.git (fetch)
 ~~~
 {: .output}
+
+We'll discuss remotes in more detail in the next episode.
 
 Once the remote is set up, this command will push the changes from
 our local repository to the repository on GitHub:
@@ -246,28 +248,6 @@ GitHub, though, this command would download them to our local repository.
 >
 > > ## Solution
 > > When we push changes, we're interacting with a remote repository to update it with the changes we've made locally (often this corresponds to sharing the changes we've made with others). Commit only updates your local repository.
-> {: .solution}
-{: .challenge}
-
-> ## Fixing Remote Settings
->
-> It happens quite often in practice that you made a typo in the
-> remote URL. This exercise is about how to fix this kind of issue.
-> First start by adding a remote with an invalid URL:
->
-> ~~~
-> git remote add broken https://github.com/this/url/is/invalid
-> ~~~
-> {: .language-bash}
->
-> Do you get an error when adding the remote? Can you think of a
-> command that would make it obvious that your remote URL was not
-> valid? Can you figure out how to fix the URL (tip: use `git remote
-> -h`)? Don't forget to clean up and remove this remote once you are
-> done with this exercise.
->
-> > ## Solution
-> > We don't see any error message when we add the remote (adding the remote tells git about it, but doesn't try to use it yet). As soon as we try to use ```git push``` we'll see an error message. The command ```git remote set-url``` allows us to change the remote's URL to fix it.
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -96,6 +96,10 @@ $ git remote add origin https://github.com/vlad/planets.git
 Make sure to use the URL for your repository rather than Vlad's: the only
 difference should be your username instead of `vlad`.
 
+`origin` is a local name used to refer to the remote repository. It could be called
+anything else, but `origin` is a convention that is often used by default in git
+and github. We'll discuss remotes in more detail in the next episode.
+
 We can check that the command has worked by running `git remote -v`:
 
 ~~~
@@ -109,10 +113,7 @@ origin   https://github.com/vlad/planets.git (fetch)
 ~~~
 {: .output}
 
-The name `origin` is a local nickname for your remote repository. We could use
-something else if we wanted to, but `origin` is by far the most common choice.
-
-Once the nickname `origin` is set up, this command will push the changes from
+Once the remote is set up, this command will push the changes from
 our local repository to the repository on GitHub:
 
 ~~~

--- a/_episodes/08-collab.md
+++ b/_episodes/08-collab.md
@@ -142,6 +142,37 @@ GitHub) are back in sync.
 > read and review.
 {: .callout}
 
+> ## Some more about remotes
+>
+> In this episode and the previous one, our local repository has had
+> a single "remote", called `origin`. A remote is a copy of the repository
+> that is hosted somewhere else, that we can push to and pull from, and 
+> there's no reason that you have to work with only one. For example, 
+> on some large projects you might have your own copy in your own Github
+> account (you'd probably call this `origin`) and also the main "upstream"
+> project repository (let's call this `upstream` for the sake of examples).
+> You would pull from `upstream` from time to 
+> time to get the latest updates that other people have comitted.
+>
+> Remember that the name you give to a remote only exists locally. It's
+> an alias that you choose - whether `origin`, or `upstream`, or `fred` -
+> and not something intrinstic to the remote repository.
+>
+> The `git remote` family of commands is used to set up and alter the remotes
+> associated with our repository. Here are some of the most useful ones:
+>
+> * `git remote -v` lists all the remotes that are configured (we already used
+> this in the last episode)
+> * `git remote add [name] [url]` is used to add a new remote
+> * `git remote remove [name]` removes a remote. Note that it doesn't affect the 
+> remote repository at all - it just removes the link to it from the local repo.
+> * `git remote set-url [name] [newurl]` changes the URL that is associated 
+> with the remote. This is useful if it has moved, e.g. to a different Github
+> account, or from Github to a different hosting service.
+> * `git remote rename [oldname] [newname]` changes the local alias by which a remote 
+> is known - its name. For example, one could use this to change `upstream` to `fred`.
+{: .callout}
+
 > ## Switch Roles and Repeat
 >
 > Switch roles and repeat the whole process.

--- a/_episodes/08-collab.md
+++ b/_episodes/08-collab.md
@@ -123,7 +123,8 @@ sensible choice earlier when we were setting up remotes by hand.)
 > remote repository at all - it just removes the link to it from the local repo.
 > * `git remote set-url [name] [newurl]` changes the URL that is associated 
 > with the remote. This is useful if it has moved, e.g. to a different Github
-> account, or from Github to a different hosting service.
+> account, or from Github to a different hosting service. Or, if we made a typo when
+> adding it!
 > * `git remote rename [oldname] [newname]` changes the local alias by which a remote 
 > is known - its name. For example, one could use this to change `upstream` to `fred`.
 {: .callout}

--- a/_episodes/08-collab.md
+++ b/_episodes/08-collab.md
@@ -114,7 +114,7 @@ sensible choice earlier when we were setting up remotes by hand.)
 > and not something intrinstic to the remote repository.
 >
 > The `git remote` family of commands is used to set up and alter the remotes
-> associated with our repository. Here are some of the most useful ones:
+> associated with a repository. Here are some of the most useful ones:
 >
 > * `git remote -v` lists all the remotes that are configured (we already used
 > this in the last episode)

--- a/_episodes/08-collab.md
+++ b/_episodes/08-collab.md
@@ -97,6 +97,37 @@ Note that we didn't have to create a remote called `origin`: Git uses this
 name by default when we clone a repository.  (This is why `origin` was a
 sensible choice earlier when we were setting up remotes by hand.)
 
+> ## Some more about remotes
+>
+> In this episode and the previous one, our local repository has had
+> a single "remote", called `origin`. A remote is a copy of the repository
+> that is hosted somewhere else, that we can push to and pull from, and 
+> there's no reason that you have to work with only one. For example, 
+> on some large projects you might have your own copy in your own Github
+> account (you'd probably call this `origin`) and also the main "upstream"
+> project repository (let's call this `upstream` for the sake of examples).
+> You would pull from `upstream` from time to 
+> time to get the latest updates that other people have comitted.
+>
+> Remember that the name you give to a remote only exists locally. It's
+> an alias that you choose - whether `origin`, or `upstream`, or `fred` -
+> and not something intrinstic to the remote repository.
+>
+> The `git remote` family of commands is used to set up and alter the remotes
+> associated with our repository. Here are some of the most useful ones:
+>
+> * `git remote -v` lists all the remotes that are configured (we already used
+> this in the last episode)
+> * `git remote add [name] [url]` is used to add a new remote
+> * `git remote remove [name]` removes a remote. Note that it doesn't affect the 
+> remote repository at all - it just removes the link to it from the local repo.
+> * `git remote set-url [name] [newurl]` changes the URL that is associated 
+> with the remote. This is useful if it has moved, e.g. to a different Github
+> account, or from Github to a different hosting service.
+> * `git remote rename [oldname] [newname]` changes the local alias by which a remote 
+> is known - its name. For example, one could use this to change `upstream` to `fred`.
+{: .callout}
+
 Take a look to the Owner's repository on its GitHub website now (maybe you need
 to refresh your browser.) You should be able to see the new commit made by the
 Collaborator.
@@ -140,37 +171,6 @@ GitHub) are back in sync.
 > It is better to make many commits with smaller changes rather than
 > of one commit with massive changes: small commits are easier to
 > read and review.
-{: .callout}
-
-> ## Some more about remotes
->
-> In this episode and the previous one, our local repository has had
-> a single "remote", called `origin`. A remote is a copy of the repository
-> that is hosted somewhere else, that we can push to and pull from, and 
-> there's no reason that you have to work with only one. For example, 
-> on some large projects you might have your own copy in your own Github
-> account (you'd probably call this `origin`) and also the main "upstream"
-> project repository (let's call this `upstream` for the sake of examples).
-> You would pull from `upstream` from time to 
-> time to get the latest updates that other people have comitted.
->
-> Remember that the name you give to a remote only exists locally. It's
-> an alias that you choose - whether `origin`, or `upstream`, or `fred` -
-> and not something intrinstic to the remote repository.
->
-> The `git remote` family of commands is used to set up and alter the remotes
-> associated with our repository. Here are some of the most useful ones:
->
-> * `git remote -v` lists all the remotes that are configured (we already used
-> this in the last episode)
-> * `git remote add [name] [url]` is used to add a new remote
-> * `git remote remove [name]` removes a remote. Note that it doesn't affect the 
-> remote repository at all - it just removes the link to it from the local repo.
-> * `git remote set-url [name] [newurl]` changes the URL that is associated 
-> with the remote. This is useful if it has moved, e.g. to a different Github
-> account, or from Github to a different hosting service.
-> * `git remote rename [oldname] [newname]` changes the local alias by which a remote 
-> is known - its name. For example, one could use this to change `upstream` to `fred`.
 {: .callout}
 
 > ## Switch Roles and Repeat


### PR DESCRIPTION
As per Issue #359, I've

1. Added some brief explanation about the use of `origin` in episode 7, and 
2. Removed the exercise about `git remote set-url` at the end of ep 7 and instead put a callout in Ep 8 to explain more about remotes and some of the commands that are available.

I'm happy to adjust for style or content if it doesn't quite fit as is :)