### PR TITLE
changed Git install URL to be consistent with other episodes

### DIFF
--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -47,8 +47,9 @@ our computer, we choose the option "Existing Directory":
 > - `where git` (Windows)
 >
 > If there is no version of Git on your computer, 
-please either install 
-[Git](https://swcarpentry.github.io/git-novice/setup.html)
+please follow the 
+[Git installation 
+instructions](https://swcarpentry.github.io/git-novice/setup.html)
 > in the setup of this lesson to install Git now. Next open your shell or command prompt 
 > and type `which git` (Mac, Linux), or `where git` (Windows).
 > Copy the path to the git executable.

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -49,7 +49,7 @@ our computer, we choose the option "Existing Directory":
 > If there is no version of Git on your computer, 
 please either install 
 [Git](https://swcarpentry.github.io/git-novice/setup.html)
-> or [GitHub](https://desktop.github.com/) now. Next open your shell or command prompt 
+> in the setup of this lesson to install Git now. Next open your shell or command prompt 
 > and type `which git` (Mac, Linux), or `where git` (Windows).
 > Copy the path to the git executable.
 >

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -46,7 +46,9 @@ our computer, we choose the option "Existing Directory":
 > - `which git` (Mac, Linux)
 > - `where git` (Windows)
 >
-> If there is no version of Git on your computer, please either install [Git](https://git-scm.com/downloads/)
+> If there is no version of Git on your computer, 
+please either install 
+[Git](https://swcarpentry.github.io/git-novice/setup.html)
 > or [GitHub](https://desktop.github.com/) now. Next open your shell or command prompt 
 > and type `which git` (Mac, Linux), or `where git` (Windows).
 > Copy the path to the git executable.


### PR DESCRIPTION
I changed the URL fir Git install so it is consistent among episodes, as suggested here: https://github.com/swcarpentry/git-novice/issues/590#issue-403400970 Does the other URL need to be edited as well?

The website it leads to is a little strange. Is the learner to change directory to desktop and then install or install and then change directory? It might be evident in the normal flow of a lesson. 