### PR TITLE
Broken link in lesson 07-github per issue #618

### DIFF
--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -51,7 +51,7 @@ $ git init
 ~~~
 {: .language-bash}
 
-If you remember back to the earlier [lesson](./04-changes.html) where we added and
+If you remember back to the earlier [lesson](../04-changes/) where we added and
 commited our earlier work on `mars.txt`, we had a diagram of the local repository
 which looked like this:
 


### PR DESCRIPTION
Fix the broken link at Line 54 per issue #618.  The proper link format is `(../04-changes/)`