### PR TITLE
fixes #624 formatting in docs now reflects actual git status output

### DIFF
--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -38,6 +38,7 @@ Untracked files:
 	b.dat
 	c.dat
 	results/
+
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
 {: .output}
@@ -80,6 +81,7 @@ Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
 	.gitignore
+
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
 {: .output}


### PR DESCRIPTION
This should fix the formatting mismatch found in Episode 6.

This is for my instructor training contribution, the first of many.
