### PR TITLE
update history references to address #621

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -74,7 +74,7 @@ again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to them:
 
 
 ~~~
-$ git diff HEAD~2 mars.txt
+$ git diff HEAD~3 mars.txt
 ~~~
 {: .language-bash}
 
@@ -94,7 +94,7 @@ index df0654a..b36abfd 100644
 We could also use `git show` which shows us what changes we made at an older commit as well as the commit message, rather than the _differences_ between a commit and our working directory that we see by using `git diff`.
 
 ~~~
-$ git show HEAD~2 mars.txt
+$ git show HEAD~3 mars.txt
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
This PR fixes swcarpentry/git-novice#621. In the discussion of that PR I've pointed out that these reference updates make the corresponding output match only if the instructor follows the callout box from Episode 04 that commits the files in the spaceships directory. 