### PR TITLE
Update output for exercise per issue #632

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -453,8 +453,8 @@ moving backward and forward in time becomes much easier.
 > > not the version in the staging area.
 > > 
 > > So, when `git commit -m "Comment on Venus as an unsuitable base"` is executed, 
-> > `venus.txt` committed to the repository is the version from the staging area and
-> >  has only one line.
+> > the version of `venus.txt` committed to the repository is the one from the staging area and
+> > has only one line.
 > >  
 > >  At this time, the working copy still has the second line (and 
 > >  `git status` will show that the file is modified). However, `git checkout HEAD venus.txt` 

--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -91,7 +91,9 @@ index df0654a..b36abfd 100644
 ~~~
 {: .output}
 
-We could also use `git show` which shows us what changes we made at an older commit as well as the commit message, rather than the _differences_ between a commit and our working directory that we see by using `git diff`.
+We could also use `git show` which shows us what changes we made at an older commit as 
+well as the commit message, rather than the _differences_ between a commit and our 
+working directory that we see by using `git diff`.
 
 ~~~
 $ git show HEAD~3 mars.txt
@@ -194,7 +196,7 @@ Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
 
-	modified:   mars.txt
+    modified:   mars.txt
 
 no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
@@ -249,7 +251,7 @@ On branch master
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
-	modified:   mars.txt
+    modified:   mars.txt
 
 ~~~
 {: .output}
@@ -374,13 +376,14 @@ moving backward and forward in time becomes much easier.
 > > `data_cruncher.py`. Answer 2 uses `HEAD` to indicate the *latest*, whereas answer 4 uses the 
 > > unique ID of the last commit, which is what `HEAD` means. 
 > > 
-> > Answer 3 gets the version of `data_cruncher.py` from the commit *before* `HEAD`, which is NOT what 
-> > we wanted.
+> > Answer 3 gets the version of `data_cruncher.py` from the commit *before* `HEAD`, which is NOT 
+> > what we wanted.
 > > 
 > > Answer 1 can be dangerous! Without a filename, `git checkout` will restore **all files** 
-> > in the current directory (and all directories below it) to their state at the commit specified. This
-> > command will restore `data_cruncher.py` to the latest commit version, but it will also restore
-> > *any other files that are changed* to that version, erasing any changes you may have made to those files!
+> > in the current directory (and all directories below it) to their state at the commit specified. 
+> > This command will restore `data_cruncher.py` to the latest commit version, but it will also 
+> > restore *any other files that are changed* to that version, erasing any changes you may 
+> > have made to those files!
 > > As discussed above, you are left in a *detached* `HEAD` state, and you don't want to be there.
 > {: .solution}
 {: .challenge}
@@ -445,14 +448,23 @@ moving backward and forward in time becomes much easier.
 > >
 > > The answer is 2. 
 > > 
-> > The command `git add venus.txt` places the *current version* of `venus.txt`
-> > into the staging area. Subsequent changes to `venus.txt` are not included in the version in the 
-> > staging area. Thus, when `git add venus.txt` is issued, there is just one line in the file, and so
-> > the copy in the staging area has just one line. When the second line is appended to `venus.txt`, 
-> > the change resides in the working directory, but the copy in the staging area still has just one line.
-> > So, when the commit is issued, the file committed to the repository has just one line. The working 
-> > copy still has the second line (and `git status` will show that the file is modified). 
+> > The command `git add venus.txt` places the current version of `venus.txt` into the staging area. 
+> > The changes to the file from the second `echo` command are only applied to the working copy, 
+> > not the version in the staging area.
 > > 
+> > So, when `git commit -m "Comment on Venus as an unsuitable base"` is executed, 
+> > `venus.txt` committed to the repository is the version from the staging area and
+> >  has only one line.
+> >  
+> >  At this time, the working copy still has the second line (and 
+> >  `git status` will show that the file is modified). However, `git checkout HEAD venus.txt` 
+> >  replaces the working copy with the most recently committed version of `venus.txt`.
+> >  
+> >  So, `cat venus.txt` will output 
+> >  ~~~
+> >  Venus is beautiful and full of love.
+> > ~~~
+> > {: .output}
 > {: .solution}
 {: .challenge}
 
@@ -495,7 +507,8 @@ moving backward and forward in time becomes much easier.
 > Unfortunately some of these commit messages are very ambiguous e.g. `update files`.
 > How can you search through these files?
 >
-> Both `git diff` and `git log` are very useful and they summarize a different part of the history for you.
+> Both `git diff` and `git log` are very useful and they summarize a different part of the history 
+> for you.
 > Is it possible to combine both? Let's try the following:
 >
 > ~~~
@@ -503,7 +516,8 @@ moving backward and forward in time becomes much easier.
 > ~~~
 > {: .language-bash}
 >
-> You should get a long list of output, and you should be able to see both commit messages and the difference between each commit.
+> You should get a long list of output, and you should be able to see both commit messages and 
+> the difference between each commit.
 >
 > Question: What does the following command do?
 >


### PR DESCRIPTION
Update output for exercise **Understanding Workflow and History** per issue #632 to provide a clearer answer for the exercise. This is done to eliminate ambiguities, which might confuse a novice learner.

Also, corrected line lengths in the file per [Carpentries guidelines](https://carpentries.github.io/lesson-example/04-formatting/index.html).