### PR TITLE
Fix link to swcarpentry github org in hosting module 

### DIFF
--- a/_episodes/13-hosting.md
+++ b/_episodes/13-hosting.md
@@ -41,7 +41,7 @@ collaborate.  Using a popular service can help connect your project with
 communities already using the same service.
 
 As an example, Software Carpentry [is on
-GitHub]({{ swc_github }}) where you can find the [source for this
+GitHub]({{ site.swc_github }}) where you can find the [source for this
 page](https://github.com/swcarpentry/git-novice/blob/gh-pages/_episodes/13-hosting.md).
 Anyone with a GitHub account can suggest changes to this text.
 


### PR DESCRIPTION
This fixes swcarpentry/git-novice#622. There was an issue with the page linking to the swcarpentry github organization, and I discovered that the variable set in _config.yml needed to be prefixed by `site.` to properly link to the URL specified in the config file. This PR should fix the linking. 

