### PR TITLE
update show command to reference first commit

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -99,9 +99,9 @@ $ git show HEAD~3 mars.txt
 {: .language-bash}
 
 ~~~
-commit 34961b159c27df3b475cfe4415d94a6d1fcd064d
+commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
 Author: Vlad Dracula <vlad@tran.sylvan.ia>
-Date:   Thu Aug 22 10:07:21 2013 -0400
+Date:   Thu Aug 22 09:51:46 2013 -0400
 
     Start notes on Mars as a base
 


### PR DESCRIPTION
This fixes swcarpentry/git-novice#623. In that issue, it was pointed out that `git show HEAD~2` (now updated to `HEAD~3` is intended to show the first commit, but the header of the command refers to the second commit. I've updated the header to be the first commit, as intended. 