### PR TITLE
update episode 7 to reflect current output per issue #625.

### DIFF
--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -130,14 +130,15 @@ $ git push origin master
 {: .language-bash}
 
 ~~~
-Counting objects: 9, done.
-Delta compression using up to 4 threads.
-Compressing objects: 100% (6/6), done.
-Writing objects: 100% (9/9), 821 bytes, done.
-Total 9 (delta 2), reused 0 (delta 0)
-To https://github.com/vlad/planets
+Enumerating objects: 16, done.
+Counting objects: 100% (16/16), done.
+Delta compression using up to 8 threads.
+Compressing objects: 100% (11/11), done.
+Writing objects: 100% (16/16), 1.45 KiB | 372.00 KiB/s, done.
+Total 16 (delta 2), reused 0 (delta 0)
+remote: Resolving deltas: 100% (2/2), done.
+To https://github.com/vlad/planets.git
  * [new branch]      master -> master
-Branch master set up to track remote branch master from origin.
 ~~~
 {: .output}
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -173,6 +173,10 @@ particular set of files in `.gitignore`.
 *   It is very useful to draw a diagram showing the different repositories
     involved.
 
+*   Learners using syntax from GitHub, `git push -u origin master`, will have slightly different 
+    output, including the line `Branch master set up to track remote branch master from origin by 
+    rebasing.`
+
 ## [Collaborating]({{ page.root }}/08-collab/)
 
 *   Decide in advance whether all the learners will work in one shared

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -173,9 +173,14 @@ particular set of files in `.gitignore`.
 *   It is very useful to draw a diagram showing the different repositories
     involved.
 
-*   Learners using syntax from GitHub, `git push -u origin master`, will have slightly different 
-    output, including the line `Branch master set up to track remote branch master from origin by 
-    rebasing.`
+*   When pushing to a remote, the output from Git can vary slightly depending 
+    on what leaners execute. The lesson displays the output from git if a 
+    learner executes `git push origin master`. However, some learners might 
+    use syntax suggested by GitHub for pushing to a remote with an existing 
+    repository, which is `git push -u origin master`. Learners using syntax from 
+    GitHub, `git push -u origin master`, will have slightly different output, 
+    including the line `Branch master set up to track remote branch master 
+    from origin by rebasing.`
 
 ## [Collaborating]({{ page.root }}/08-collab/)
 


### PR DESCRIPTION
Update episode 7 to reflect current output per issue #625. Also, update instructor guide, as suggested to call out differences in output if using github suggested syntax and push includes upstream (e.g. `git push -u origin master`).