### PR TITLE
update outputs of push and pull commands in Episode 09 

### DIFF
--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -71,12 +71,14 @@ $ git push origin master
 {: .language-bash}
 
 ~~~
-Counting objects: 5, done.
-Delta compression using up to 4 threads.
+Enumerating objects: 5, done.
+Counting objects: 100% (5/5), done.
+Delta compression using up to 8 threads
 Compressing objects: 100% (3/3), done.
-Writing objects: 100% (3/3), 352 bytes, done.
-Total 3 (delta 1), reused 0 (delta 0)
-To https://github.com/vlad/planets
+Writing objects: 100% (3/3), 331 bytes | 331.00 KiB/s, done.
+Total 3 (delta 2), reused 0 (delta 0)
+remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
+To https://github.com/vlad/planets.git
    29aba7c..dabb4c8  master -> master
 ~~~
 {: .output}
@@ -122,11 +124,12 @@ $ git push origin master
 
 ~~~
 To https://github.com/vlad/planets.git
- ! [rejected]        master -> master (non-fast-forward)
+ ! [rejected]        master -> master (fetch first)
 error: failed to push some refs to 'https://github.com/vlad/planets.git'
-hint: Updates were rejected because the tip of your current branch is behind
-hint: its remote counterpart. Merge the remote changes (e.g. 'git pull')
-hint: before pushing again.
+hint: Updates were rejected because the remote contains work that you do
+hint: not have locally. This is usually caused by another repository pushing
+hint: to the same ref. You may want to first integrate the remote changes
+hint: (e.g., 'git pull ...') before pushing again.
 hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 ~~~
 {: .output}
@@ -146,12 +149,14 @@ $ git pull origin master
 {: .language-bash}
 
 ~~~
-remote: Counting objects: 5, done.
-remote: Compressing objects: 100% (2/2), done.
-remote: Total 3 (delta 1), reused 3 (delta 1)
+remote: Enumerating objects: 5, done.
+remote: Counting objects: 100% (5/5), done.
+remote: Compressing objects: 100% (1/1), done.
+remote: Total 3 (delta 2), reused 3 (delta 2), pack-reused 0
 Unpacking objects: 100% (3/3), done.
 From https://github.com/vlad/planets
  * branch            master     -> FETCH_HEAD
+    29aba7c..dabb4c8  master     -> origin/master
 Auto-merging mars.txt
 CONFLICT (content): Merge conflict in mars.txt
 Automatic merge failed; fix conflicts and then commit the result.
@@ -248,11 +253,13 @@ $ git push origin master
 {: .language-bash}
 
 ~~~
-Counting objects: 10, done.
-Delta compression using up to 4 threads.
+Enumerating objects: 10, done.
+Counting objects: 100% (10/10), done.
+Delta compression using up to 8 threads
 Compressing objects: 100% (6/6), done.
-Writing objects: 100% (6/6), 697 bytes, done.
-Total 6 (delta 2), reused 0 (delta 0)
+Writing objects: 100% (6/6), 645 bytes | 645.00 KiB/s, done.
+Total 6 (delta 4), reused 0 (delta 0)
+remote: Resolving deltas: 100% (4/4), completed with 2 local objects.
 To https://github.com/vlad/planets.git
    dabb4c8..2abf2b1  master -> master
 ~~~
@@ -268,12 +275,14 @@ $ git pull origin master
 {: .language-bash}
 
 ~~~
-remote: Counting objects: 10, done.
-remote: Compressing objects: 100% (4/4), done.
-remote: Total 6 (delta 2), reused 6 (delta 2)
+remote: Enumerating objects: 10, done.
+remote: Counting objects: 100% (10/10), done.
+remote: Compressing objects: 100% (2/2), done.
+remote: Total 6 (delta 4), reused 6 (delta 4), pack-reused 0
 Unpacking objects: 100% (6/6), done.
 From https://github.com/vlad/planets
  * branch            master     -> FETCH_HEAD
+    dabb4c8..2abf2b1  master     -> origin/master
 Updating dabb4c8..2abf2b1
 Fast-forward
  mars.txt | 2 +-

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -275,6 +275,9 @@ particular set of files in `.gitignore`.
     You still have to `git add` and `git commit` after this. This is
     particularly useful when working with binary files.
 
+*   Keep in mind that depending on the Git version used, the outputs for
+    `git push` and `git pull` can vary slightly. 
+
 ## [Open Science]({{ page.root }}/10-open/)
 
 ## [Licensing]({{ page.root }}/11-licensing/)


### PR DESCRIPTION
resolves swcarpentry/git-novice#627

This PR updates the outputs in the Conflicts episode to match those given by a more recent version of Git. The distribution that new learners will have is more likely to be a recent version, and this will help make sure the lessons match what they'll most likely see on their own machines. 

I've also added a note to the instructor guide noting the differences in outputs for git versions. Recent PRs note this in other sections of the guide, so this supplements them.