### PR TITLE
revise conflicts key point to reflect line differences

### DIFF
--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -8,7 +8,7 @@ objectives:
 - "Explain what conflicts are and when they can occur."
 - "Resolve conflicts resulting from a merge."
 keypoints:
-- "Conflicts occur when two or more people change the same file(s) at the same time."
+- "Conflicts occur when two or more people change the same lines of the same file."
 - "The version control system does not allow people to overwrite each other's changes blindly, but highlights conflicts so that they can be resolved."
 ---
 


### PR DESCRIPTION
This PR resolves swcarpentry/git-novice#629 

I've revised the key point to say that conflicts occur when the same lines of the same file are changed, not just that the same file is changed. 