### PR TITLE
updating ignore lesson based on discussion in #634

### DIFF
--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -172,7 +172,7 @@ nothing to commit, working directory clean
 > >
 > > As with most programming issues, there
 > > are a few alternative ways that one may ensure this ignore rule is followed.
-> > The "Ignoring Nested Files with More Directories" exercise has a slightly
+> > The "Ignoring Nested Files: Variation" exercise has a slightly
 > > different directory structure
 > > that presents an alternative solution.
 > > Further, the discussion page has more detail on ignore rules.
@@ -200,6 +200,40 @@ nothing to commit, working directory clean
 > > Note also that because you've previously committed `.dat` files in this
 > > lesson they will not be ignored with this new rule. Only future additions
 > > of `.dat` files added to the root directory will be ignored.
+> {: .solution}
+{: .challenge}
+
+> ## Ignoring Nested Files: Variation
+>
+> Given a directory structure that looks similar to the earlier Nested Files
+> exercise, but with a slightly different directory structure:
+>
+> ~~~
+> results/data
+> results/images
+> results/plots
+> results/analysis
+> ~~~
+> {: .language-bash}
+>
+> How would you ignore all of the contents in the results folder, but not `results/data`?
+>
+> Hint: think a bit about how you created an exception with the `!` operator
+> before.
+>
+> > ## Solution
+> >
+> > If you want to ignore the contents of
+> > `results/` but not those of `results/data/`, you can change your `.gitignore` to ignore
+> > the contents of results folder, but create an exception for the contents of the
+> > `results/data` subfolder. Your .gitignore would look like this:
+> >
+> > ~~~
+> > results/*               # ignore everything in results folder
+> > !results/data/          # do not ignore results/data/ contents
+> > ~~~
+> > {: .output}
+> >
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -157,22 +157,25 @@ nothing to commit, working directory clean
 >
 > > ## Solution
 > >
-> > As with most programming issues, there are a few ways that you
-> > could solve this. If you only want to ignore the contents of
+> > If you only want to ignore the contents of
 > > `results/plots`, you can change your `.gitignore` to ignore
 > > only the `/plots/` subfolder by adding the following line to
 > > your .gitignore:
 > >
-> > `results/plots/`
+> > ~~~
+> > results/plots/
+> > ~~~
+> > {: .output}
 > >
-> > If, instead, you want to ignore everything in `/results/`, but wanted to track
-> > `results/data`, then you can add `results/` to your .gitignore
-> > and create an exception for the `results/data/` folder.
-> > The next challenge will cover this type of solution.
+> > This line will ensure only the contents of `results/plots` is ignored, and
+> > not the contents of `results/data`.
 > >
-> > Sometimes the `**` pattern comes in handy, too, which matches
-> > multiple directory levels. E.g. `**/results/plots/*` would make git ignore
-> > the `results/plots` directory in any root directory.
+> > As with most programming issues, there
+> > are a few alternative ways that one may ensure this ignore rule is followed.
+> > The "Ignoring Nested Files with More Directories" exercise has a slightly
+> > different directory structure
+> > that presents an alternative solution.
+> > Further, the discussion page has more detail on ignore rules.
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -178,8 +178,8 @@ nothing to commit, working directory clean
 
 > ## Including Specific Files
 >
-> How would you ignore all `.data` files in your root directory except for
-> `final.data`?
+> How would you ignore all `.dat` files in your root directory except for
+> `final.dat`?
 > Hint: Find out what `!` (the exclamation point operator) does
 >
 > > ## Solution
@@ -187,12 +187,16 @@ nothing to commit, working directory clean
 > > You would add the following two lines to your .gitignore:
 > >
 > > ~~~
-> > *.data           # ignore all data files
-> > !final.data      # except final.data
+> > *.dat           # ignore all data files
+> > !final.dat      # except final.data
 > > ~~~
 > > {: .output}
 > >
 > > The exclamation point operator will include a previously excluded entry.
+> >
+> > Note also that because you've previously committed `.dat` files in this
+> > lesson they will not be ignored with this new rule. Only future additions
+> > of `.dat` files added to the root directory will be ignored.
 > {: .solution}
 {: .challenge}
 
@@ -201,20 +205,21 @@ nothing to commit, working directory clean
 > Given a directory structure that looks like:
 >
 > ~~~
-> results/data/position/gps/a.data
-> results/data/position/gps/b.data
-> results/data/position/gps/c.data
+> results/data/position/gps/a.dat
+> results/data/position/gps/b.dat
+> results/data/position/gps/c.dat
 > results/data/position/gps/info.txt
 > results/plots
 > ~~~
 > {: .language-bash}
 >
-> What's the shortest `.gitignore` rule you could write to ignore all `.data`
+> What's the shortest `.gitignore` rule you could write to ignore all `.dat`
 > files in `result/data/position/gps`? Do not ignore the `info.txt`.
 >
 > > ## Solution
 > >
-> > Appending `results/data/position/gps/*.data` will match every file in `results/data/position/gps` that ends with `.data`.
+> > Appending `results/data/position/gps/*.dat` will match every file in `results/data/position/gps`
+> > that ends with `.dat`.
 > > The file `results/data/position/gps/info.txt` will not be ignored.
 > {: .solution}
 {: .challenge}
@@ -224,8 +229,8 @@ nothing to commit, working directory clean
 > Given a `.gitignore` file with the following contents:
 >
 > ~~~
-> *.data
-> !*.data
+> *.dat
+> !*.dat
 > ~~~
 > {: .language-bash}
 >
@@ -234,8 +239,8 @@ nothing to commit, working directory clean
 > > ## Solution
 > >
 > > The `!` modifier will negate an entry from a previously defined ignore pattern.
-> > Because the `!*.data` entry negates all of the previous `.data` files in the `.gitignore`,
-> > none of them will be ignored, and all `.data` files will be tracked.
+> > Because the `!*.dat` entry negates all of the previous `.dat` files in the `.gitignore`,
+> > none of them will be ignored, and all `.dat` files will be tracked.
 > >
 > {: .solution}
 {: .challenge}

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -239,7 +239,7 @@ nothing to commit, working directory clean
 
 > ## Ignoring all data Files in a Directory
 >
-> Given a directory structure that looks like:
+> Assuming you have an empty .gitignore file, and given a directory structure that looks like:
 >
 > ~~~
 > results/data/position/gps/a.dat

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -456,3 +456,54 @@ $ git commit -m 'Superman's home is Earth, told you before.'
 ~~~
 {: .language-bash}
 	
+## Further .gitignore concepts
+
+For additional documentation on .gitignore, please reference
+[the official git documentation](https://git-scm.com/docs/gitignore).
+
+In the ignore exercise, learners were presented with two variations of ignoring
+nested files. Depending on the organization of your repository, one may suit
+your needs over another. Keep in mind that the way that Git travels along
+directory paths can be confusing. 
+
+Sometimes the `**` pattern comes in handy, too, which matches multiple
+directory levels. E.g. `**/results/plots/*` would make git ignore the
+`results/plots` directory in any root directory.  
+
+> ## Ignoring Nested Files: Challenge Problem
+>
+> Given a directory structure that looks like:
+>
+> ~~~
+> results/data
+> results/plots
+> results/run001.log
+> results/run002.log
+> ~~~
+> {: .language-bash}
+> 
+> And a .gitignore that looks like:
+>
+> ~~~
+> *.dat
+> ~~~
+> {: .output}
+>
+> How would you track all of the contents of `results/data/`, including `*.dat`
+> files, but ignore the rest of `results/`?
+>
+> > ## Solution
+> >
+> > To do this, your .gitignore would look like this:
+> >
+> > ~~~
+> > *.dat                 # ignore the .dat files
+> > results/*             # ignore the files in the results directory
+> > !results/data/        # do not ignore the files in results/data
+> > !results/data/*       # do not ignore the .dat files in reults/data
+> > ~~~
+> > {: .output}
+> > 
+> {: .solution}
+{: .challenge}
+


### PR DESCRIPTION
This PR should resolve swcarpentry/git-novice#634. It's a bit long, and I'm happy to delete any of the content I've added if it's unnecessary. 

Generally, it:
- changes the .data files in the exercises to .dat to be consistent with the rest of the lesson. I noticed that this then generated a problem with one of the exercises that had data files that were supposed to be committed (because the lesson adds *.dat to the gitignore), so I added a line noting that. 
- attempts to modify the "Ignoring Nested Files" exercise to point the learners to the most obvious solution. 
- creates an additional exercise that uses the exception operator with a directory rather than a file. The prompt is similar to the original nested files exercise. 
- added content to the discussion page that links to the official git documentation. I also added a challenge exercise here that matches what was discussed in the linked issue, but it might not be appropriate because there aren't challenge exercises for the rest of the discussion. 

Let me know what you think! Hopefully I captured everything discussed in that issue. 