### PR TITLE
Fixing broken links and the All-In-One page

### DIFF
--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -49,9 +49,9 @@ Unless multiple users make changes to the same section of the document - a confl
 A version control system is a tool that keeps track of these changes for us,
 effectively creating different versions of our files. It allows us to decide
 which changes will be made to the next version (each record of these changes is
-called a [commit]({% link reference.md %}#commit)), and keeps useful metadata
+called a [commit]({{ page.root }}{% link reference.md %}#commit)), and keeps useful metadata
 about them. The complete history of commits for a particular project and their
-metadata make up a [repository]({% link reference.md %}#repository).
+metadata make up a [repository]({{ page.root }}{% link reference.md %}#repository).
 Repositories can be kept in sync across different computers, facilitating
 collaboration among different people.
 

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -40,7 +40,7 @@ $ cd planets
 ~~~
 {: .language-bash}
 
-Then we tell Git to make `planets` a [repository]({% link reference.md %}#repository)—a place where Git can store versions of our files:
+Then we tell Git to make `planets` a [repository]({{ page.root }}{% link reference.md %}#repository)—a place where Git can store versions of our files:
 
 ~~~
 $ git init

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -154,8 +154,8 @@ $ git commit -m "Start notes on Mars as a base"
 When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
 and stores a copy permanently inside the special `.git` directory.
-This permanent copy is called a [commit]({% link reference.md %}#commit)
-(or [revision]({% link reference.md %}#revision)) and its short identifier is `f22b25e`. Your commit may have another identifier.
+This permanent copy is called a [commit]({{ page.root }}{% link reference.md %}#commit)
+(or [revision]({{ page.root }}{% link reference.md %}#revision)) and its short identifier is `f22b25e`. Your commit may have another identifier.
 
 We use the `-m` flag (for "message")
 to record a short, descriptive, and specific comment that will help us remember later on what we did and why.
@@ -345,7 +345,7 @@ but *not* commit some of our work drafting the conclusion
 To allow for this,
 Git has a special *staging area*
 where it keeps track of things that have been added to
-the current [changeset]({% link reference.md %}#changeset)
+the current [changeset]({{ page.root }}{% link reference.md %}#changeset)
 but not yet committed.
 
 > ## Staging Area

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -68,13 +68,13 @@ Note that our local repository still contains our earlier work on `mars.txt`, bu
 remote repository on GitHub appears empty as it doesn't contain any files yet.
 
 The next step is to connect the two repositories.  We do this by making the
-GitHub repository a [remote]({% link reference.md %}#remote) for the local repository.
+GitHub repository a [remote]({{ page.root}}{% link reference.md %}#remote) for the local repository.
 The home page of the repository on GitHub includes the string we need to
 identify it:
 
 ![Where to Find Repository URL on GitHub](../fig/github-find-repo-string.png)
 
-Click on the 'HTTPS' link to change the [protocol]({% link reference.md %}#protocol) from SSH to HTTPS.
+Click on the 'HTTPS' link to change the [protocol]({{ page.root }}{% link reference.md %}#protocol) from SSH to HTTPS.
 
 > ## HTTPS vs. SSH
 >
@@ -249,7 +249,7 @@ GitHub, though, this command would download them to our local repository.
 > Create a remote repository on GitHub. Push the contents of your local
 > repository to the remote. Make changes to your local repository and push these
 > changes. Go to the repo you just created on GitHub and check the
-> [timestamps]({% link reference.md %}#timestamp) of the files. How does GitHub
+> [timestamps]({{ page.root }}{% link reference.md %}#timestamp) of the files. How does GitHub
 > record times, and why?
 >
 > > ## Solution

--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -16,8 +16,8 @@ As soon as people can work in parallel, they'll likely step on each other's
 toes.  This will even happen with a single person: if we are working on
 a piece of software on both our laptop and a server in the lab, we could make
 different changes to each copy.  Version control helps us manage these
-[conflicts]({% link reference.md %}#conflict) by giving us tools to
-[resolve]({% link reference.md %}#resolve) overlapping changes.
+[conflicts]({{ page.root}}{% link reference.md %}#conflict) by giving us tools to
+[resolve]({{ page.root }}{% link reference.md %}#resolve) overlapping changes.
 
 To see how we can resolve conflicts, we must first create one.  The file
 `mars.txt` currently looks like this in both partners' copies of our `planets`
@@ -139,7 +139,7 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 Git rejects the push because it detects that the remote repository has new updates that have not been
 incorporated into the local branch.
 What we have to do is pull the changes from GitHub,
-[merge]({% link reference.md %}#merge) them into the copy we're currently working in, and then push that.
+[merge]({{ page.root }}{% link reference.md %}#merge) them into the copy we're currently working in, and then push that.
 Let's start by pulling:
 
 ~~~

--- a/_episodes/10-open.md
+++ b/_episodes/10-open.md
@@ -97,7 +97,7 @@ by acting as a shareable electronic lab notebook for computational work:
 >
 > Anything that is hosted in a version control repository (data, code, papers, 
 > etc.) can be turned into a citable object. You'll learn how to do this in
-> [lesson 12: Citation]({% link _episodes/12-citation.md %}).
+> [lesson 12: Citation]({{ page.root }}{% link _episodes/12-citation.md %}).
 {: .callout}
 
 > ## How Reproducible Is My Work?

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -79,7 +79,7 @@ working in teams or not, because it is
     *    [Code School][code-school] has a free interactive course, [Try Git][try-git].
     *    for instructors, [the Git parable][git-parable] is useful background reading
 
-## [Automated Version Control]({% link _episodes/01-basics.md %})
+## [Automated Version Control]({{ page.root }}{% link _episodes/01-basics.md %})
 
 *   Ask, "Who uses 'undo' in their editor?" All say "Me". 'Undo' is the simplest
     form of version control.
@@ -94,7 +94,7 @@ working in teams or not, because it is
     and, "come on this really has to be the last version" to motivate version
     control as a better way to collaborate and as a better way to back work up.
 
-## [Setting Up Git]({% link _episodes/02-setup.md %})
+## [Setting Up Git]({{ page.root }}{% link _episodes/02-setup.md %})
 
 *   We suggest instructors and students use `nano` as the text editor for this
     lessons because
@@ -110,7 +110,7 @@ working in teams or not, because it is
     common for them to edit the instructor's details (e.g. email).  Check at
     the end using `git config --list`.
 
-## [Creating a Repository]({% link _episodes/03-create.md %})
+## [Creating a Repository]({{ page.root }}{% link _episodes/03-create.md %})
 
 *   When you do `git status`, Mac users may see a `.DS_Store` file showing as
     untracked. This a file that Mac OS creates in each directory.
@@ -132,7 +132,7 @@ working in teams or not, because it is
     The challenge suggests that it is a bad idea to create a Git repo inside another repo.
     For more discussion on this topic, please see [this issue][repos-in-repos].
 
-## [Tracking Changes]({% link _episodes/04-changes.md %})
+## [Tracking Changes]({{ page.root }}{% link _episodes/04-changes.md %})
 
 *   It's important that learners do a full commit cycle by themselves (make
     changes, `git diff`, `git add`, and `git commit`). The "`bio` repository"
@@ -152,12 +152,12 @@ working in teams or not, because it is
 *   This is a good moment to show a log within a Git GUI. If you skip it
     because you're short on time, show it once in GitHub.
 
-## [Ignoring Things]({% link _episodes/06-ignore.md %})
+## [Ignoring Things]({{ page.root }}{% link _episodes/06-ignore.md %})
 
 Just remember that you can use wildcards and regular expressions to ignore a
 particular set of files in `.gitignore`.
 
-## [Remotes in GitHub]({% link _episodes/07-github.md %})
+## [Remotes in GitHub]({{ page.root }}{% link _episodes/07-github.md %})
 
 *   Make it clear that Git and GitHub are not the same thing: Git is an open
     source version control tool, GitHub is a company that hosts Git
@@ -180,7 +180,7 @@ particular set of files in `.gitignore`.
     `git push -u origin master`, will have slightly different output, including
     the line `Branch master set up to track remote branch master from origin by rebasing.`
 
-## [Collaborating]({% link _episodes/08-collab.md %})
+## [Collaborating]({{ page.root }}{% link _episodes/08-collab.md %})
 
 *   Decide in advance whether all the learners will work in one shared
     repository, or whether they will work in pairs (or other small groups) in
@@ -248,7 +248,7 @@ particular set of files in `.gitignore`.
 *   Learners may have slightly different output from `git push` and `git pull`
     depending on the version of git, and if upstream (`-u`) is used.
 
-## [Conflicts]({% link _episodes/09-conflict.md %})
+## [Conflicts]({{ page.root }}{% link _episodes/09-conflict.md %})
 
 *   Expect the learners to make mistakes. Expect *yourself* to make mistakes.
     This happens because it is late in the lesson and everyone is tired.
@@ -276,18 +276,18 @@ particular set of files in `.gitignore`.
 *  Keep in mind that depending on the Git version used, the outputs for
    `git push` and `git pull` can vary slightly.
 
-## [Open Science]({% link _episodes/10-open.md %})
+## [Open Science]({{ page.root }}{% link _episodes/10-open.md %})
 
-## [Licensing]({% link _episodes/11-licensing.md %})
+## [Licensing]({{ page.root }}{% link _episodes/11-licensing.md %})
 
 We teach about licensing because questions about who owns what, or can use
 what, arise naturally once we start talking about using public services like
 GitHub to store files. Also, the discussion gives learners a chance to catch
 their breath after what is often a frustrating couple of hours.
 
-## [Citation]({% link _episodes/12-citation.md %})
+## [Citation]({{ page.root }}{% link _episodes/12-citation.md %})
 
-## [Hosting]({% link _episodes/13-hosting.md %})
+## [Hosting]({{ page.root }}{% link _episodes/13-hosting.md %})
 
 A common concern for learners is having their work publicly available on
 GitHub.  While we encourage open science, sometimes private repos are the

--- a/aio.md
+++ b/aio.md
@@ -1,6 +1,4 @@
 ---
-layout: page 
-permalink: /aio/
 ---
 <script>
   window.onload = function() {


### PR DESCRIPTION
Hi, this is just a collection of tiny fixes to get some broken links working. There were some "{{ page.root }}"s missing on various pages so the relative paths were broken for several things.

Also the All-In-One page is currently broken, so this includes a small change to fix that (by removing header information).
