### PR TITLE
Update history episode with better terminology

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -256,7 +256,7 @@ Changes to be committed:
 ~~~
 {: .output}
 
-Notice that the changes are on the staged area.
+Notice that the changes are currently in the staging area.
 Again, we can put things back the way they were
 by using `git checkout`:
 

--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -308,7 +308,7 @@ It's important to remember that
 we must use the commit number that identifies the state of the repository
 *before* the change we're trying to undo.
 A common mistake is to use the number of
-the commit in which we made the change we're trying to get rid of.
+the commit in which we made the change we're trying to discard.
 In the example below, we want to retrieve the state from before the most
 recent commit (`HEAD~1`), which is commit `f22b25e`:
 


### PR DESCRIPTION
This PR aims at improving the readability of the fifth chapter of the git-novice lessons. Specifically, I suggested two changes:

- Replacing `staged area` with `staging area`

and 

- Replacing `get rid of` with `discard`

I believe that this is more common terminology in the Git lingo. Let me know what you think.
