### PR TITLE
link to more detailed explanation of core.autocrlf configuration option

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -54,7 +54,7 @@ For these lessons, we will be interacting with [GitHub](https://github.com/) and
 > Because Git uses these characters to compare files,
 > it may cause unexpected issues when editing a file on different machines. 
 > Though it is beyond the scope of this lesson, you can read more about this issue 
-> [on this GitHub page](https://help.github.com/articles/dealing-with-line-endings/).
+> [in the Pro Git book](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf).
 {: .callout}
 >
 > You can change the way Git recognizes and encodes line endings

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -58,6 +58,9 @@ working in teams or not, because it is
     these issues, since learners will almost certainly trip over them
     again.  If learners are running into line ending problems, GitHub
     has a [page][github-line-endings] that helps with troubleshooting.
+    Specifically, the [section on refreshing a repository][github-line-endings-refresh]
+    may be helpful if learners need to change the `core.autocrlf` setting
+    after already having made one or more commits.
 
 *   We don't use a Git GUI in these notes because we haven't found one that
     installs easily and runs reliably on the three major operating systems, and
@@ -302,7 +305,8 @@ web-hosted private repositories.
 [git-parable]: http://tom.preston-werner.com/2009/05/19/the-git-parable.html
 [github]: https://github.com/
 [github-gui]: https://git-scm.com/downloads/guis
-[github-line-endings]: https://help.github.com/articles/dealing-with-line-endings/#platform-all
+[github-line-endings]: https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings
+[github-line-endings-refresh]: https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings
 [github-privacy]: https://help.github.com/articles/keeping-your-email-address-private/
 [repos-in-repos]: https://github.com/swcarpentry/git-novice/issues/272
 [try-git]: https://try.github.io


### PR DESCRIPTION
This PR replaces a link to supplementary documentation about the `core.autocrlf` config option that I found to be inadequate for a couple reasons:

- It doesn't offer much more than the inline explanation in the Carpentries lesson itself, in terms of justifying the config setting, beyond "for properly handling line endings". The new link concretely explains potential sources of the issue and describes the actual file transformations that take place with each setting.
- This issue is fundamentally about Git and not GitHub, so a link to the Git documentation is more appropriate.