### PR TITLE
Add explanations for additional git log flags

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -536,17 +536,20 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > {: .language-bash}
 > ~~~
-> * 005937f Discuss concerns about Mars' climate for Mummy
-> * 34961b1 Add concerns about effects of Mars' moons on Wolfman
-> * f22b25e Start notes on Mars as a base
+> 005937f Discuss concerns about Mars' climate for Mummy
+> 34961b1 Add concerns about effects of Mars' moons on Wolfman
+> f22b25e Start notes on Mars as a base
 > ~~~
 > {: .output}
 >
-> You can also combine the `--oneline` options with others. One useful
-> combination is:
+> You can also combine the `--oneline` option with others. One useful
+> combination adds `--graph` to display the commit history as a text-based
+> graph and `--decorate` to indicate which commits are associated with the
+> current `HEAD`, the current branch `master`, or
+> [other Git references][git-references]:
 >
 > ~~~
-> $ git log --oneline --graph --all --decorate
+> $ git log --oneline --graph --decorate
 > ~~~
 > {: .language-bash}
 > ~~~
@@ -777,5 +780,6 @@ repository (`git commit`):
 {: .challenge}
 
 [commit-messages]: https://chris.beams.io/posts/git-commit/
+[git-references]: https://git-scm.com/book/en/v2/Git-Internals-Git-References
 
 {% include links.md %}


### PR DESCRIPTION
Adds explanations for the flags used in the example for how to combine multiple git log flags with `--oneline` and corrects the output for the first `git log --oneline` example where the commit hashes should not have "*" prefixes (these prefixes are drawn by the `--graph` flag).

For clarity, this commit also removes the `--all` flag from the combined flags example since this flag does not change the output of git log in the simple repository of this lesson and requires a longer explanation of git references than there is time to cover during the novice lesson. The description of the `--decorate` flag does provide a link to the official documentation for git references, for learners who wish to study this subject in more detail on their own.

Closes #536.