### PR TITLE
Removing "#" in "git status" output demo in 03-create.md

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -88,10 +88,10 @@ $ git status
 ~~~
 {: .language-bash}
 ~~~
-# On branch master
-#
-# Initial commit
-#
+On branch master
+
+Initial commit
+
 nothing to commit (create/copy files and use "git add" to track)
 ~~~
 {: .output}


### PR DESCRIPTION
I suggest removing "#" in "git status" output demo to match the actual output on the terminal.

