### PR TITLE
aio: Update image links

### DIFF
--- a/_includes/all_figures.html
+++ b/_includes/all_figures.html
@@ -1,55 +1,55 @@
-<p><img alt="Adding Collaborators on GitHub" src="../fig/github-add-collaborators.png" /></p>
+<p><img alt="Adding Collaborators on GitHub" src="{{ page.root }}/fig/github-add-collaborators.png" /></p>
 <hr/>
-<p><img alt="After Creating Clone of Repository" src="../fig/github-collaboration.svg" /></p>
+<p><img alt="After Creating Clone of Repository" src="{{ page.root }}/fig/github-collaboration.svg" /></p>
 <hr/>
-<p><img alt="The Git Staging Area" src="../fig/git-staging-area.svg" /></p>
+<p><img alt="The Git Staging Area" src="{{ page.root }}/fig/git-staging-area.svg" /></p>
 <hr/>
-<p><img alt="The Git Commit Workflow" src="../fig/git-committing.svg" /></p>
+<p><img alt="The Git Commit Workflow" src="{{ page.root }}/fig/git-committing.svg" /></p>
 <hr/>
-<p><img alt="Piled Higher and Deeper by Jorge Cham, http://www.phdcomics.com/comics/archive_print.php?comicid=1531" src="../fig/phd101212s.png" /></p>
+<p><img alt="Piled Higher and Deeper by Jorge Cham, http://www.phdcomics.com/comics/archive_print.php?comicid=1531" src="{{ page.root }}/fig/phd101212s.png" /></p>
 <hr/>
-<p><img alt="Changes Are Saved Sequentially" src="../fig/play-changes.svg" /></p>
+<p><img alt="Changes Are Saved Sequentially" src="{{ page.root }}/fig/play-changes.svg" /></p>
 <hr/>
-<p><img alt="Different Versions Can be Saved" src="../fig/versions.svg" /></p>
+<p><img alt="Different Versions Can be Saved" src="{{ page.root }}/fig/versions.svg" /></p>
 <hr/>
-<p><img alt="Multiple Versions Can be Merged" src="../fig/merge.svg" /></p>
+<p><img alt="Multiple Versions Can be Merged" src="{{ page.root }}/fig/merge.svg" /></p>
 <hr/>
-<p><img alt="Git Checkout" src="../fig/git-checkout.svg" /></p>
+<p><img alt="Git Checkout" src="{{ page.root }}/fig/git-checkout.svg" /></p>
 <hr/>
-<p><img alt="https://figshare.com/articles/How_Git_works_a_cartoon/1328266" src="../fig/git_staging.svg" /></p>
+<p><img alt="https://figshare.com/articles/How_Git_works_a_cartoon/1328266" src="{{ page.root }}/fig/git_staging.svg" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_newproject.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_newproject.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_existingdirectory.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_existingdirectory.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_navigateexisting.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_navigateexisting.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_afterclone.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_afterclone.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_editfiles.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_editfiles.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_commit.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_commit.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_review.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_review.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_history.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_history.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_viewhistory.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_viewhistory.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/RStudio_screenshot_gitignore.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/RStudio_screenshot_gitignore.png" /></p>
 <hr/>
-<p><img alt="Creating a Repository on GitHub (Step 1)" src="../fig/github-create-repo-01.png" /></p>
+<p><img alt="Creating a Repository on GitHub (Step 1)" src="{{ page.root }}/fig/github-create-repo-01.png" /></p>
 <hr/>
-<p><img alt="Creating a Repository on GitHub (Step 2)" src="../fig/github-create-repo-02.png" /></p>
+<p><img alt="Creating a Repository on GitHub (Step 2)" src="{{ page.root }}/fig/github-create-repo-02.png" /></p>
 <hr/>
-<p><img alt="Creating a Repository on GitHub (Step 3)" src="../fig/github-create-repo-03.png" /></p>
+<p><img alt="Creating a Repository on GitHub (Step 3)" src="{{ page.root }}/fig/github-create-repo-03.png" /></p>
 <hr/>
-<p><img alt="Freshly-Made GitHub Repository" src="../fig/git-freshly-made-github-repo.svg" /></p>
+<p><img alt="Freshly-Made GitHub Repository" src="{{ page.root }}/fig/git-freshly-made-github-repo.svg" /></p>
 <hr/>
-<p><img alt="Where to Find Repository URL on GitHub" src="../fig/github-find-repo-string.png" /></p>
+<p><img alt="Where to Find Repository URL on GitHub" src="{{ page.root }}/fig/github-find-repo-string.png" /></p>
 <hr/>
-<p><img alt="Changing the Repository URL on GitHub" src="../fig/github-change-repo-string.png" /></p>
+<p><img alt="Changing the Repository URL on GitHub" src="{{ page.root }}/fig/github-change-repo-string.png" /></p>
 <hr/>
-<p><img alt="GitHub Repository After First Push" src="../fig/github-repo-after-first-push.svg" /></p>
+<p><img alt="GitHub Repository After First Push" src="{{ page.root }}/fig/github-repo-after-first-push.svg" /></p>
 <hr/>
-<p><img alt="The Conflicting Changes" src="../fig/conflict.svg" /></p>
+<p><img alt="The Conflicting Changes" src="{{ page.root }}/fig/conflict.svg" /></p>


### PR DESCRIPTION
This fixes https://github.com/swcarpentry/git-novice/issues/693.
![image](https://user-images.githubusercontent.com/4336207/65823417-9a56b180-e273-11e9-9c23-7da8f744a0d6.png)
Similar issues have been fixed in the same way, see https://github.com/swcarpentry/git-novice/pull/674/commits/2e833c98b706cd01d57006bc0dbd7b82bd813125.

Also this is **part of my checkout process**.