### PR TITLE
07-github.com: introduce branches, improve wording

### DIFF
--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -206,9 +206,14 @@ Our local and remote repositories are now in this state:
 > ~~~
 > {: .language-bash}
 >
-> This option instructs Git to send branch `master` to the remote `origin` and remember a
-> few things so that later we can send our changes to `origin` with `git pull` without any
-> additional arguments.
+> While the `-u` flag is cryptic, its full name -- `--set-upstream` -- is more revealing.
+> When `git push` is invoked with either of these two flags, Git updates specified branch (`master`
+> in our example) in the remote repository (`origin`) and sets that branch as
+> an _upstream branch_ for the local branch (also called `master`).
+> When a local branch knows its "upstream" branch, we can move the changes between the two (pull and
+> push) without specifying either the remote repository (e.g., `origin`) or the remote branch (e.g.,
+> `master`).
+>
 {: .callout}
 
 We can pull changes from the remote repository to the local one as well:

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -33,9 +33,9 @@ create a new repository called `planets`:
 
 Name your repository "planets" and then click "Create Repository".
 
-Note: Since this repository will be connected to a local repository, it needs to be empty. Leave 
-"Initialize this repository with a README" unchecked, and keep "None" as options for both "Add 
-.gitignore" and "Add a license." See the "GitHub License and README files" exercise below for a full 
+Note: Since this repository will be connected to a local repository, it needs to be empty. Leave
+"Initialize this repository with a README" unchecked, and keep "None" as options for both "Add
+.gitignore" and "Add a license." See the "GitHub License and README files" exercise below for a full
 explanation of why the repository needs to be empty.
 
 ![Creating a Repository on GitHub (Step 2)](../fig/github-create-repo-02.png)
@@ -141,6 +141,13 @@ To https://github.com/vlad/planets.git
 ~~~
 {: .output}
 
+In the above command we used a new word -- `master`. If the command completed successfully, the
+message that Git displays hints us that `master` is a _branch_. To put it simply, a branch is a
+sequence of changes ("commits") made to the repository. When we initialize a new repository, Git
+creates a new branch and, by default, calls it `master`. When we send ("push") our changes to the
+remote repository, we send "branches", not commits. So, in the above command we asked Git to send
+(`push`) changes in our only branch (`master`) to the remote called `origin`.
+
 > ## Proxy
 >
 > If the network you are connected to uses a proxy, there is a chance that your
@@ -190,13 +197,18 @@ Our local and remote repositories are now in this state:
 
 ![GitHub Repository After First Push](../fig/github-repo-after-first-push.svg)
 
-> ## The '-u' Flag
+> ## Upstream branch
 >
-> You may see a `-u` option used with `git push` in some documentation.  This
-> option is synonymous with the `--set-upstream-to` option for the `git branch`
-> command, and is used to associate the current branch with a remote branch so
-> that the `git pull` command can be used without any arguments. To do this,
-> simply use `git push -u origin master` once the remote has been set up.
+> You may occasionally see `git push` with an additional `-u` flag, as in:
+>
+> ~~~
+> git push -u origin master
+> ~~~
+> {: .language-bash}
+>
+> This option instructs Git to send branch `master` to the remote `origin` and remember a
+> few things so that later we can send our changes to `origin` with `git pull` without any
+> additional arguments.
 {: .callout}
 
 We can pull changes from the remote repository to the local one as well:
@@ -226,30 +238,30 @@ GitHub, though, this command would download them to our local repository.
 > How would you get that same information in the shell?
 >
 > > ## Solution
-> > The left-most button (with the picture of a clipboard) copies the full identifier of the commit 
-> > to the clipboard. In the shell, ```git log``` will show you the full commit identifier for each 
+> > The left-most button (with the picture of a clipboard) copies the full identifier of the commit
+> > to the clipboard. In the shell, ```git log``` will show you the full commit identifier for each
 > > commit.
 > >
-> > When you click on the middle button, you'll see all of the changes that were made in that 
-> > particular commit. Green shaded lines indicate additions and red ones removals. In the shell we 
-> > can do the same thing with ```git diff```. In particular, ```git diff ID1..ID2``` where ID1 and 
-> > ID2 are commit identifiers (e.g. ```git diff a3bf1e5..041e637```) will show the differences 
+> > When you click on the middle button, you'll see all of the changes that were made in that
+> > particular commit. Green shaded lines indicate additions and red ones removals. In the shell we
+> > can do the same thing with ```git diff```. In particular, ```git diff ID1..ID2``` where ID1 and
+> > ID2 are commit identifiers (e.g. ```git diff a3bf1e5..041e637```) will show the differences
 > > between those two commits.
 > >
-> > The right-most button lets you view all of the files in the repository at the time of that 
-> > commit. To do this in the shell, we'd need to checkout the repository at that particular time. 
-> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to 
-> > look at. If we do this, we need to remember to put the repository back to the right state 
+> > The right-most button lets you view all of the files in the repository at the time of that
+> > commit. To do this in the shell, we'd need to checkout the repository at that particular time.
+> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to
+> > look at. If we do this, we need to remember to put the repository back to the right state
 > > afterwards!
 > {: .solution}
 {: .challenge}
 
 > ## Uploading files directly in GitHub browser
 >
-> Github also allows you to skip the command line and upload files directly to 
-> your repository without having to leave the browser. There are two options. 
+> Github also allows you to skip the command line and upload files directly to
+> your repository without having to leave the browser. There are two options.
 > First you can click the "Upload files" button in the toolbar at the top of the
-> file tree. Or, you can drag and drop files from your desktop onto the file 
+> file tree. Or, you can drag and drop files from your desktop onto the file
 > tree. You can read more about this [on this GitHub page](https://help.github.com/articles/adding-a-file-to-a-repository/)
 {: .callout}
 
@@ -262,8 +274,8 @@ GitHub, though, this command would download them to our local repository.
 > record times, and why?
 >
 > > ## Solution
-> > GitHub displays timestamps in a human readable relative format (i.e. "22 hours ago" or "three 
-> > weeks ago"). However, if you hover over the timestamp, you can see the exact time at which the 
+> > GitHub displays timestamps in a human readable relative format (i.e. "22 hours ago" or "three
+> > weeks ago"). However, if you hover over the timestamp, you can see the exact time at which the
 > > last change to the file occurred.
 > {: .solution}
 {: .challenge}
@@ -274,22 +286,22 @@ GitHub, though, this command would download them to our local repository.
 > How is "git push" different from "git commit"?
 >
 > > ## Solution
-> > When we push changes, we're interacting with a remote repository to update it with the changes 
-> > we've made locally (often this corresponds to sharing the changes we've made with others). 
+> > When we push changes, we're interacting with a remote repository to update it with the changes
+> > we've made locally (often this corresponds to sharing the changes we've made with others).
 > > Commit only updates your local repository.
 > {: .solution}
 {: .challenge}
 
 > ## GitHub License and README files
 >
-> In this section we learned about creating a remote repository on GitHub, but when you initialized 
-> your GitHub repo, you didn't add a README.md or a license file. If you had, what do you think 
+> In this section we learned about creating a remote repository on GitHub, but when you initialized
+> your GitHub repo, you didn't add a README.md or a license file. If you had, what do you think
 > would have happened when you tried to link your local and remote repositories?
 >
 > > ## Solution
-> > In this case, we'd see a merge conflict due to unrelated histories. When GitHub creates a 
-> > README.md file, it performs a commit in the remote repository. When you try to pull the remote 
-> > repository to your local repository, Git detects that they have histories that do not share a 
+> > In this case, we'd see a merge conflict due to unrelated histories. When GitHub creates a
+> > README.md file, it performs a commit in the remote repository. When you try to pull the remote
+> > repository to your local repository, Git detects that they have histories that do not share a
 > > common origin and refuses to merge.
 > > ~~~
 > > $ git pull origin master
@@ -309,8 +321,8 @@ GitHub, though, this command would download them to our local repository.
 > > ~~~
 > > {: .output}
 > >
-> > You can force git to merge the two repositories with the option `--allow-unrelated-histories`. 
-> > Be careful when you use this option and carefully examine the contents of local and remote 
+> > You can force git to merge the two repositories with the option `--allow-unrelated-histories`.
+> > Be careful when you use this option and carefully examine the contents of local and remote
 > > repositories before merging.
 > > ~~~
 > > $ git pull --allow-unrelated-histories origin master

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -197,7 +197,7 @@ Our local and remote repositories are now in this state:
 
 ![GitHub Repository After First Push](../fig/github-repo-after-first-push.svg)
 
-> ## Upstream branch
+> ## The '-u' Flag
 >
 > You may occasionally see `git push` with an additional `-u` flag, as in:
 >
@@ -207,12 +207,10 @@ Our local and remote repositories are now in this state:
 > {: .language-bash}
 >
 > While the `-u` flag is cryptic, its full name -- `--set-upstream` -- is more revealing.
-> When `git push` is invoked with either of these two flags, Git updates specified branch (`master`
-> in our example) in the remote repository (`origin`) and sets that branch as
-> an _upstream branch_ for the local branch (also called `master`).
-> When a local branch knows its "upstream" branch, we can move the changes between the two (pull and
-> push) without specifying either the remote repository (e.g., `origin`) or the remote branch (e.g.,
-> `master`).
+> When `git push` is invoked with either of these two flags, Git
+> sends specified branch to the specified remote and remembers a few things so that
+> later we can exchange changes with the remote using `git push` and `git pull` without any
+> additional arguments.
 >
 {: .callout}
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -33,9 +33,9 @@ create a new repository called `planets`:
 
 Name your repository "planets" and then click "Create Repository".
 
-Note: Since this repository will be connected to a local repository, it needs to be empty. Leave
-"Initialize this repository with a README" unchecked, and keep "None" as options for both "Add
-.gitignore" and "Add a license." See the "GitHub License and README files" exercise below for a full
+Note: Since this repository will be connected to a local repository, it needs to be empty. Leave 
+"Initialize this repository with a README" unchecked, and keep "None" as options for both "Add 
+.gitignore" and "Add a license." See the "GitHub License and README files" exercise below for a full 
 explanation of why the repository needs to be empty.
 
 ![Creating a Repository on GitHub (Step 2)](../fig/github-create-repo-02.png)
@@ -238,30 +238,30 @@ GitHub, though, this command would download them to our local repository.
 > How would you get that same information in the shell?
 >
 > > ## Solution
-> > The left-most button (with the picture of a clipboard) copies the full identifier of the commit
-> > to the clipboard. In the shell, ```git log``` will show you the full commit identifier for each
+> > The left-most button (with the picture of a clipboard) copies the full identifier of the commit 
+> > to the clipboard. In the shell, ```git log``` will show you the full commit identifier for each 
 > > commit.
 > >
-> > When you click on the middle button, you'll see all of the changes that were made in that
-> > particular commit. Green shaded lines indicate additions and red ones removals. In the shell we
-> > can do the same thing with ```git diff```. In particular, ```git diff ID1..ID2``` where ID1 and
-> > ID2 are commit identifiers (e.g. ```git diff a3bf1e5..041e637```) will show the differences
+> > When you click on the middle button, you'll see all of the changes that were made in that 
+> > particular commit. Green shaded lines indicate additions and red ones removals. In the shell we 
+> > can do the same thing with ```git diff```. In particular, ```git diff ID1..ID2``` where ID1 and 
+> > ID2 are commit identifiers (e.g. ```git diff a3bf1e5..041e637```) will show the differences 
 > > between those two commits.
 > >
-> > The right-most button lets you view all of the files in the repository at the time of that
-> > commit. To do this in the shell, we'd need to checkout the repository at that particular time.
-> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to
-> > look at. If we do this, we need to remember to put the repository back to the right state
+> > The right-most button lets you view all of the files in the repository at the time of that 
+> > commit. To do this in the shell, we'd need to checkout the repository at that particular time. 
+> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to 
+> > look at. If we do this, we need to remember to put the repository back to the right state 
 > > afterwards!
 > {: .solution}
 {: .challenge}
 
 > ## Uploading files directly in GitHub browser
 >
-> Github also allows you to skip the command line and upload files directly to
-> your repository without having to leave the browser. There are two options.
+> Github also allows you to skip the command line and upload files directly to 
+> your repository without having to leave the browser. There are two options. 
 > First you can click the "Upload files" button in the toolbar at the top of the
-> file tree. Or, you can drag and drop files from your desktop onto the file
+> file tree. Or, you can drag and drop files from your desktop onto the file 
 > tree. You can read more about this [on this GitHub page](https://help.github.com/articles/adding-a-file-to-a-repository/)
 {: .callout}
 
@@ -274,8 +274,8 @@ GitHub, though, this command would download them to our local repository.
 > record times, and why?
 >
 > > ## Solution
-> > GitHub displays timestamps in a human readable relative format (i.e. "22 hours ago" or "three
-> > weeks ago"). However, if you hover over the timestamp, you can see the exact time at which the
+> > GitHub displays timestamps in a human readable relative format (i.e. "22 hours ago" or "three 
+> > weeks ago"). However, if you hover over the timestamp, you can see the exact time at which the 
 > > last change to the file occurred.
 > {: .solution}
 {: .challenge}
@@ -286,22 +286,22 @@ GitHub, though, this command would download them to our local repository.
 > How is "git push" different from "git commit"?
 >
 > > ## Solution
-> > When we push changes, we're interacting with a remote repository to update it with the changes
-> > we've made locally (often this corresponds to sharing the changes we've made with others).
+> > When we push changes, we're interacting with a remote repository to update it with the changes 
+> > we've made locally (often this corresponds to sharing the changes we've made with others). 
 > > Commit only updates your local repository.
 > {: .solution}
 {: .challenge}
 
 > ## GitHub License and README files
 >
-> In this section we learned about creating a remote repository on GitHub, but when you initialized
-> your GitHub repo, you didn't add a README.md or a license file. If you had, what do you think
+> In this section we learned about creating a remote repository on GitHub, but when you initialized 
+> your GitHub repo, you didn't add a README.md or a license file. If you had, what do you think 
 > would have happened when you tried to link your local and remote repositories?
 >
 > > ## Solution
-> > In this case, we'd see a merge conflict due to unrelated histories. When GitHub creates a
-> > README.md file, it performs a commit in the remote repository. When you try to pull the remote
-> > repository to your local repository, Git detects that they have histories that do not share a
+> > In this case, we'd see a merge conflict due to unrelated histories. When GitHub creates a 
+> > README.md file, it performs a commit in the remote repository. When you try to pull the remote 
+> > repository to your local repository, Git detects that they have histories that do not share a 
 > > common origin and refuses to merge.
 > > ~~~
 > > $ git pull origin master
@@ -321,8 +321,8 @@ GitHub, though, this command would download them to our local repository.
 > > ~~~
 > > {: .output}
 > >
-> > You can force git to merge the two repositories with the option `--allow-unrelated-histories`.
-> > Be careful when you use this option and carefully examine the contents of local and remote
+> > You can force git to merge the two repositories with the option `--allow-unrelated-histories`. 
+> > Be careful when you use this option and carefully examine the contents of local and remote 
 > > repositories before merging.
 > > ~~~
 > > $ git pull --allow-unrelated-histories origin master


### PR DESCRIPTION
1. Explained what `master` in

```sh
git push origin master
```

means.

2. Improved wording of the section that explains `-u` flag.

Currently it mentions `git branch` and its `--set-upstream-to` flag...
and leaves it at that. Rewrote this callout box so that we speak in human terms, not
in Git terms.


3. As a diligent contributor... I'm keeping the text below)))


Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

---