### PR TITLE
Update log --graph output & remove redundant --decorate

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -553,7 +553,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > {: .language-bash}
 > ~~~
-> * 005937f Discuss concerns about Mars' climate for Mummy (HEAD, master)
+> * 005937f (HEAD -> master) Discuss concerns about Mars' climate for Mummy
 > * 34961b1 Add concerns about effects of Mars' moons on Wolfman
 > * f22b25e Start notes on Mars as a base
 > ~~~

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -544,12 +544,12 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 >
 > You can also combine the `--oneline` option with others. One useful
 > combination adds `--graph` to display the commit history as a text-based
-> graph and `--decorate` to indicate which commits are associated with the
+> graph and to indicate which commits are associated with the
 > current `HEAD`, the current branch `master`, or
 > [other Git references][git-references]:
 >
 > ~~~
-> $ git log --oneline --graph --decorate
+> $ git log --oneline --graph
 > ~~~
 > {: .language-bash}
 > ~~~


### PR DESCRIPTION
I'm not exactly sure [when Git changed this](https://github.com/git/git/search?l=Text&q=log+graph+decorate), but I checked these changes in both Windows' Git bash (2.22.0.windows.1) & on macOS' Git (2.24.0): `--decorate` is no longer necesary to show `HEAD` & branch names. Thus, that concept could be remove to simplify the lesson.

- [x] Can someone please verify on Linux?