### PR TITLE
added typical number of characters when using short commit ids

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -156,7 +156,7 @@ index df0654a..93a3e13 100644
 
 That's the right answer,
 but typing out random 40-character strings is annoying,
-so Git lets us use just the first few characters:
+so Git lets us use just the first few characters (typically seven for normal size projects):
 
 ~~~
 $ git diff f22b25e mars.txt


### PR DESCRIPTION
The original document did not specify how many character you should use when using short ids for identifying commits. The [official documentation](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1) page suggests eight to ten characters, but from the context it is clear that for "normal" size projects seven characters are also good. 
Seven characters are also consistent with the "tracking changes" lecture where the command:
```
git log --oneline
```
is used and outputs logs with 7-characters ids for commits.