### PR TITLE
Remove # from output, because not printed by git

### DIFF
--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -100,7 +100,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-# On branch master
+On branch master
 nothing to commit, working directory clean
 ~~~
 {: .output}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -369,12 +369,11 @@ $ git status
 {: .language-bash}
 
 ~~~
-# On branch master
-# Changes to be committed:
-#   (use "git reset HEAD <file>..." to unstage)
-#
-#	renamed:    krypton.txt -> earth.txt
-#
+On branch master
+Changes to be committed:
+  (use "git reset HEAD <file>..." to unstage)
+
+	renamed:    krypton.txt -> earth.txt
 ~~~
 {: .output}
 The final step is commit our change to the repository:


### PR DESCRIPTION
These `#` may have been present years ago, but are no longer.