### PR TITLE
Fix GitHub render of linked images and in-repo file sections

### DIFF
--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -17,7 +17,7 @@ to keep track of what one person did and when.
 Even if you aren't collaborating with other people,
 automated version control is much better than this situation:
 
-[![Piled Higher and Deeper by Jorge Cham, http://www.phdcomics.com/comics/archive_print.php?comicid=1531](../figs/phd101212s.png)](http://www.phdcomics.com)
+[![Piled Higher and Deeper by Jorge Cham, http://www.phdcomics.com/comics/archive_print.php?comicid=1531](../fig/phd101212s.png)](http://www.phdcomics.com)
 
 "Piled Higher and Deeper" by Jorge Cham, http://www.phdcomics.com
 
@@ -35,19 +35,19 @@ think of it as a recording of your progress: you can rewind to start at the base
 document and play back each change you made, eventually arriving at your
 more recent version.
 
-![Changes Are Saved Sequentially](../figs/play-changes.svg)
+![Changes Are Saved Sequentially](../fig/play-changes.svg)
 
 Once you think of changes as separate from the document itself, you
 can then think about "playing back" different sets of changes on the base document, ultimately
 resulting in different versions of that document. For example, two users can make independent
 sets of changes on the same document. 
 
-![Different Versions Can be Saved](../figs/versions.svg)
+![Different Versions Can be Saved](../fig/versions.svg)
 
 Unless multiple users make changes to the same section of the document - a conflict - you can 
 incorporate two sets of changes into the same base document.
 
-![Multiple Versions Can be Merged](../figs/merge.svg)
+![Multiple Versions Can be Merged](../fig/merge.svg)
 
 A version control system is a tool that keeps track of these changes for us,
 effectively creating different versions of our files. It allows us to decide

--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -17,7 +17,7 @@ to keep track of what one person did and when.
 Even if you aren't collaborating with other people,
 automated version control is much better than this situation:
 
-[![Piled Higher and Deeper by Jorge Cham, http://www.phdcomics.com/comics/archive_print.php?comicid=1531]({{ page.root }}/fig/phd101212s.png)](http://www.phdcomics.com)
+[![Piled Higher and Deeper by Jorge Cham, http://www.phdcomics.com/comics/archive_print.php?comicid=1531](../figs/phd101212s.png)](http://www.phdcomics.com)
 
 "Piled Higher and Deeper" by Jorge Cham, http://www.phdcomics.com
 
@@ -35,19 +35,19 @@ think of it as a recording of your progress: you can rewind to start at the base
 document and play back each change you made, eventually arriving at your
 more recent version.
 
-![Changes Are Saved Sequentially]({{ page.root }}/fig/play-changes.svg)
+![Changes Are Saved Sequentially](../figs/play-changes.svg)
 
 Once you think of changes as separate from the document itself, you
 can then think about "playing back" different sets of changes on the base document, ultimately
 resulting in different versions of that document. For example, two users can make independent
 sets of changes on the same document. 
 
-![Different Versions Can be Saved]({{ page.root }}/fig/versions.svg)
+![Different Versions Can be Saved](../figs/versions.svg)
 
 Unless multiple users make changes to the same section of the document - a conflict - you can 
 incorporate two sets of changes into the same base document.
 
-![Multiple Versions Can be Merged]({{ page.root }}/fig/merge.svg)
+![Multiple Versions Can be Merged](../figs/merge.svg)
 
 A version control system is a tool that keeps track of these changes for us,
 effectively creating different versions of our files. It allows us to decide

--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -52,9 +52,9 @@ incorporate two sets of changes into the same base document.
 A version control system is a tool that keeps track of these changes for us,
 effectively creating different versions of our files. It allows us to decide
 which changes will be made to the next version (each record of these changes is
-called a [commit]({{ page.root }}{% link reference.md %}#commit)), and keeps useful metadata
+called a [commit](../reference.md#commit)), and keeps useful metadata
 about them. The complete history of commits for a particular project and their
-metadata make up a [repository]({{ page.root }}{% link reference.md %}#repository).
+metadata make up a [repository](../reference.md#repository).
 Repositories can be kept in sync across different computers, facilitating
 collaboration among different people.
 

--- a/reference.md
+++ b/reference.md
@@ -48,7 +48,7 @@ remote
 :   (of a repository) A version control [repository](#repository) connected to another,
     in such way that both can be kept in sync exchanging [commits](#commit).
 
-repository
+<a id=repository>repository</a>
 :   A storage area where a [version control](#version-control) system
     stores the full history of [commits](#commit) of a project and information
     about who changed what, when.

--- a/reference.md
+++ b/reference.md
@@ -19,7 +19,7 @@ changeset
     to a single [commit](#commit) in a [version control](#version-control)
     [repository](#repository).
 
-commit
+<a id=commit>commit</a>
 :   To record the current state of a set of files (a [changeset](#changeset))
     in a [version control](#version-control) [repository](#repository). As a noun,
     the result of committing, i.e. a recorded changeset in a repository.


### PR DESCRIPTION
For episode 01, changed the link format for the images and some texts (`commit` and `repository`) to use relative links to point to the figures (in `fig`) or file sections (in `reference.md`). The edit is with guidance of GitHub Flavored Markdown, may or may not render correctly on other platforms (untested). 