### PR TITLE
Update the logic and colours of rows in figures, Fixes #357

### DIFF
--- a/fig/conflict.svg
+++ b/fig/conflict.svg
@@ -1,57 +1,309 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="664px" height="354px" viewBox="0 0 664 354" enable-background="new 0 0 664 354" xml:space="preserve">
-<g>
-	<rect x="33" y="111" fill="#DCDEE0" width="100" height="127"/>
-	<rect x="33" y="111" fill="none" stroke="#85888D" stroke-width="2" width="100" height="127"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="46" y1="131" x2="120" y2="131"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="46" y1="137" x2="120" y2="137"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="46" y1="142" x2="120" y2="142"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="46" y1="154" x2="120" y2="154"/>
-	<rect x="500" y="111" fill="#DCDEE0" width="100" height="127"/>
-	<rect x="500" y="111" fill="none" stroke="#85888D" stroke-width="2" width="100" height="127"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="513" y1="131" x2="587" y2="131"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="513" y1="137" x2="587" y2="137"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="513" y1="142" x2="587" y2="142"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="513" y1="154" x2="587" y2="154"/>
-	<rect x="255" y="23" fill="#DCDEE0" width="100" height="128"/>
-	<rect x="255" y="23" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="268" y1="43" x2="342" y2="43"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="268" y1="49" x2="342" y2="49"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="268" y1="55" x2="342" y2="55"/>
-	<line fill="none" stroke="#70BF41" stroke-width="2" x1="268" y1="67" x2="342" y2="67"/>
-	<line fill="none" stroke="#70BF41" stroke-width="2" x1="157" y1="59" x2="231" y2="59"/>
-	<line fill="none" stroke="#70BF41" stroke-width="2" x1="392.763" y1="59" x2="466.763" y2="59"/>
 
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="461.52" y1="172.158" x2="535.52" y2="172.158"/>
-	<polygon fill="#45BEEE" points="203.427,125.067 207.724,139.122 237.382,98.616 190.144,81.62 194.44,95.675 153.541,108.179 
-	162.527,137.571 "/>
-	<polygon fill="#45BEEE" points="437.427,238.712 441.724,252.767 471.382,212.261 424.144,195.265 428.44,209.319 387.541,221.824 
-	396.527,251.216 "/>
-	<rect x="255" y="203" fill="#DCDEE0" width="100" height="128"/>
-	<rect x="255" y="203" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="268" y1="223" x2="342" y2="223"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="268" y1="229" x2="342" y2="229"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="268" y1="235" x2="342" y2="235"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="268" y1="247" x2="342" y2="247"/>
-	<polygon fill="#45BEEE" points="194.44,238.713 190.144,252.767 237.382,235.771 207.724,195.266 203.427,209.32 162.527,196.815 
-	153.541,226.208 "/>
-	<polygon fill="#45BEEE" points="428.44,125.068 424.144,139.121 471.382,122.125 441.724,81.621 437.427,95.675 396.527,83.17 
-	387.541,112.563 "/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="268" y1="253" x2="342" y2="253"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="158" y1="268" x2="231" y2="268"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="158" y1="274" x2="231" y2="274"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="393" y1="268" x2="466" y2="268"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="393" y1="274" x2="466" y2="274"/>	
-		<line fill="none" stroke="#C82506" stroke-width="2" x1="568.678" y1="180.189" x2="641.678" y2="180.189"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="664px"
+   height="354px"
+   viewBox="0 0 664 354"
+   enable-background="new 0 0 664 354"
+   xml:space="preserve"
+   sodipodi:docname="conflict.svg"
+   inkscape:version="0.92.4 (unknown)"><metadata
+   id="metadata87"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs85">
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
 
-		<line fill="none" stroke="#C82506" stroke-width="2" x1="568.678" y1="186.189" x2="641.678" y2="186.189"/>
-	<path d="M546.585,185.594l-0.043-1.123c-0.13-2.203,0.604-4.45,2.549-6.739c1.382-1.685,2.506-3.11,2.506-4.536
-		c0-1.512-0.994-2.548-3.154-2.592c-1.425,0-3.153,0.519-4.276,1.296l-1.469-4.708c1.599-0.907,4.147-1.771,7.214-1.771
-		c5.702,0,8.338,3.153,8.338,6.739c0,3.283-2.074,5.442-3.716,7.257c-1.555,1.771-2.246,3.456-2.202,5.399v0.778H546.585z
-		 M545.462,191.598c0-2.332,1.599-3.931,3.845-3.931c2.333,0,3.845,1.599,3.888,3.931c0,2.246-1.512,3.932-3.888,3.932
-		C547.018,195.529,545.462,193.844,545.462,191.598z"/>
-</g>
+		
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+		
+		
+
+		
+	
+</defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1133"
+   id="namedview83"
+   showgrid="false"
+   inkscape:zoom="1.8915663"
+   inkscape:cx="302.47604"
+   inkscape:cy="177"
+   inkscape:window-x="1920"
+   inkscape:window-y="38"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<g
+   id="g972"><rect
+     x="33"
+     y="111"
+     width="100"
+     height="127"
+     id="rect2"
+     style="fill:#f7f7f7" /><rect
+     x="33"
+     y="111"
+     width="100"
+     height="127"
+     id="rect4"
+     style="fill:none;stroke:#85888d;stroke-width:2" /><line
+     x1="46"
+     y1="131"
+     x2="120"
+     y2="131"
+     id="line6"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="46"
+     y1="137"
+     x2="120"
+     y2="137"
+     id="line8"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="46"
+     y1="142"
+     x2="120"
+     y2="142"
+     id="line10"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="46"
+     y1="154"
+     x2="120"
+     y2="154"
+     id="line12"
+     style="fill:none;stroke:#000000;stroke-width:2" /><rect
+     x="500"
+     y="111"
+     width="100"
+     height="127"
+     id="rect14"
+     style="fill:#f7f7f7" /><rect
+     x="500"
+     y="111"
+     width="100"
+     height="127"
+     id="rect16"
+     style="fill:none;stroke:#85888d;stroke-width:2" /><line
+     x1="513"
+     y1="131"
+     x2="587"
+     y2="131"
+     id="line18"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="513"
+     y1="137"
+     x2="587"
+     y2="137"
+     id="line20"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="513"
+     y1="142"
+     x2="587"
+     y2="142"
+     id="line22"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="513"
+     y1="154"
+     x2="587"
+     y2="154"
+     id="line24"
+     style="fill:none;stroke:#000000;stroke-width:2" /><rect
+     x="255"
+     y="23"
+     width="100"
+     height="128"
+     id="rect26"
+     style="fill:#f7f7f7" /><rect
+     x="255"
+     y="23"
+     width="100"
+     height="128"
+     id="rect28"
+     style="fill:none;stroke:#85888d;stroke-width:2" /><line
+     x1="268"
+     y1="43"
+     x2="342"
+     y2="43"
+     id="line30"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="268"
+     y1="49"
+     x2="342"
+     y2="49"
+     id="line32"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="268"
+     y1="55"
+     x2="342"
+     y2="55"
+     id="line34"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="268"
+     y1="67"
+     x2="342"
+     y2="67"
+     id="line36"
+     style="fill:none;stroke:#f1a340;stroke-width:2" /><line
+     x1="157"
+     y1="59"
+     x2="231"
+     y2="59"
+     id="line38"
+     style="fill:none;stroke:#f1a340;stroke-width:2" /><line
+     x1="392.763"
+     y1="59"
+     x2="466.763"
+     y2="59"
+     id="line40"
+     style="fill:none;stroke:#f1a340;stroke-width:2" /><line
+     x1="461.51999"
+     y1="172.158"
+     x2="535.52002"
+     y2="172.158"
+     id="line42"
+     style="fill:none;stroke:#f1a340;stroke-width:2" /><polygon
+     points="237.382,98.616 190.144,81.62 194.44,95.675 153.541,108.179 162.527,137.571 203.427,125.067 207.724,139.122 "
+     id="polygon44"
+     style="fill:#d8daeb" /><polygon
+     points="471.382,212.261 424.144,195.265 428.44,209.319 387.541,221.824 396.527,251.216 437.427,238.712 441.724,252.767 "
+     id="polygon46"
+     style="fill:#d8daeb" /><rect
+     x="255"
+     y="203"
+     width="100"
+     height="128"
+     id="rect48"
+     style="fill:#f7f7f7" /><rect
+     x="255"
+     y="203"
+     width="100"
+     height="128"
+     id="rect50"
+     style="fill:none;stroke:#85888d;stroke-width:2" /><line
+     x1="268"
+     y1="223"
+     x2="342"
+     y2="223"
+     id="line52"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="268"
+     y1="229"
+     x2="342"
+     y2="229"
+     id="line54"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="268"
+     y1="235"
+     x2="342"
+     y2="235"
+     id="line56"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="268"
+     y1="247"
+     x2="342"
+     y2="247"
+     id="line58"
+     style="fill:none;stroke:#998ec3;stroke-width:2" /><polygon
+     points="237.382,235.771 207.724,195.266 203.427,209.32 162.527,196.815 153.541,226.208 194.44,238.713 190.144,252.767 "
+     id="polygon60"
+     style="fill:#d8daeb" /><polygon
+     points="471.382,122.125 441.724,81.621 437.427,95.675 396.527,83.17 387.541,112.563 428.44,125.068 424.144,139.121 "
+     id="polygon62"
+     style="fill:#d8daeb" /><line
+     x1="268"
+     y1="253"
+     x2="342"
+     y2="253"
+     id="line64"
+     style="fill:none;stroke:#998ec3;stroke-width:2" /><line
+     x1="158"
+     y1="268"
+     x2="231"
+     y2="268"
+     id="line66"
+     style="fill:none;stroke:#998ec3;stroke-width:2" /><line
+     x1="158"
+     y1="274"
+     x2="231"
+     y2="274"
+     id="line68"
+     style="fill:none;stroke:#998ec3;stroke-width:2" /><line
+     x1="393"
+     y1="268"
+     x2="466"
+     y2="268"
+     id="line70"
+     style="fill:none;stroke:#998ec3;stroke-width:2" /><line
+     x1="393"
+     y1="274"
+     x2="466"
+     y2="274"
+     id="line72"
+     style="fill:none;stroke:#998ec3;stroke-width:2" /><line
+     x1="568.67798"
+     y1="180.189"
+     x2="641.67798"
+     y2="180.189"
+     id="line74"
+     style="fill:none;stroke:#998ec3;stroke-width:2" /><line
+     x1="568.67798"
+     y1="186.189"
+     x2="641.67798"
+     y2="186.189"
+     id="line76"
+     style="fill:none;stroke:#998ec3;stroke-width:2" /><path
+     d="m 546.585,185.594 -0.043,-1.123 c -0.13,-2.203 0.604,-4.45 2.549,-6.739 1.382,-1.685 2.506,-3.11 2.506,-4.536 0,-1.512 -0.994,-2.548 -3.154,-2.592 -1.425,0 -3.153,0.519 -4.276,1.296 l -1.469,-4.708 c 1.599,-0.907 4.147,-1.771 7.214,-1.771 5.702,0 8.338,3.153 8.338,6.739 0,3.283 -2.074,5.442 -3.716,7.257 -1.555,1.771 -2.246,3.456 -2.202,5.399 v 0.778 z m -1.123,6.004 c 0,-2.332 1.599,-3.931 3.845,-3.931 2.333,0 3.845,1.599 3.888,3.931 0,2.246 -1.512,3.932 -3.888,3.932 -2.289,-0.001 -3.845,-1.686 -3.845,-3.932 z"
+     id="path78"
+     inkscape:connector-curvature="0" /></g>
 </svg>

--- a/fig/merge.svg
+++ b/fig/merge.svg
@@ -1,40 +1,244 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="398px" height="382px" viewBox="0 0 398 382" enable-background="new 0 0 398 382" xml:space="preserve">
-<g>
-	<rect x="266" y="129" fill="#DCDEE0" width="100" height="127"/>
-	<rect x="266" y="129" fill="none" stroke="#85888D" stroke-width="2" width="100" height="127"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="279" y1="149" x2="353" y2="149"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="279" y1="155" x2="353" y2="155"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="279" y1="160" x2="353" y2="160"/>
-	<line fill="none" stroke="#70BF41" stroke-width="2" x1="279" y1="172" x2="353" y2="172"/>
-	<rect x="32" y="41" fill="#DCDEE0" width="100" height="128"/>
-	<rect x="32" y="41" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="45" y1="61" x2="119" y2="61"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="45" y1="67" x2="119" y2="67"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="45" y1="73" x2="119" y2="73"/>
-	<line fill="none" stroke="#70BF41" stroke-width="2" x1="45" y1="85" x2="119" y2="85"/>
-	<line fill="none" stroke="#70BF41" stroke-width="2" x1="162" y1="155" x2="236" y2="155"/>
-</g>
-<g>
-	<rect x="32" y="221" fill="#DCDEE0" width="100" height="128"/>
-	<rect x="32" y="221" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="45" y1="241" x2="119" y2="241"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="45" y1="247" x2="119" y2="247"/>
-	<line fill="none" stroke="#000000" stroke-width="2" x1="45" y1="253" x2="119" y2="253"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="45" y1="265" x2="119" y2="265"/>
-</g>
-<polygon fill="#45BEEE" points="205.711,272.768 210.008,286.822 239.666,246.316 192.428,229.32 196.725,243.375 155.825,255.879 
-	164.812,285.271 "/>
-<polygon fill="#45BEEE" points="197.488,131.384 193.191,145.438 240.43,128.443 210.771,87.937 206.475,101.992 165.574,89.487 
-	156.588,118.88 "/>
-<g>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="45" y1="271" x2="119" y2="271"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="162" y1="208" x2="236" y2="208"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="162" y1="214" x2="236" y2="214"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="279" y1="179" x2="353" y2="179"/>
-	<line fill="none" stroke="#C82506" stroke-width="2" x1="279" y1="185" x2="353" y2="185"/>
-</g>
-</svg>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="398px"
+   height="382px"
+   viewBox="0 0 398 382"
+   enable-background="new 0 0 398 382"
+   xml:space="preserve"
+   sodipodi:docname="merge.svg"
+   inkscape:version="0.92.4 (unknown)"><metadata
+   id="metadata65"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs63">
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+
+	
+	
+	
+	
+	
+
+	
+	
+	
+	
+	
+	
+</defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1133"
+   id="namedview61"
+   showgrid="false"
+   inkscape:zoom="0.87370262"
+   inkscape:cx="192.42602"
+   inkscape:cy="166.72034"
+   inkscape:window-x="1920"
+   inkscape:window-y="38"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1"
+   inkscape:snap-grids="true"><inkscape:grid
+     type="xygrid"
+     id="grid4664" /></sodipodi:namedview>
+<rect
+   style="fill:#f7f7f7;stroke:#fc8d59;stroke-opacity:1;fill-opacity:1"
+   id="rect2"
+   height="127"
+   width="100"
+   y="129"
+   x="266" /><rect
+   style="fill:none;stroke:#85888d;stroke-width:2"
+   id="rect4"
+   height="127"
+   width="100"
+   y="129"
+   x="266" /><line
+   style="fill:none;stroke:#000000;stroke-width:2"
+   id="line6"
+   y2="149"
+   x2="353"
+   y1="149"
+   x1="279" /><line
+   style="fill:none;stroke:#f1a340;stroke-width:2;stroke-opacity:1"
+   id="line8"
+   y2="155"
+   x2="353"
+   y1="155"
+   x1="279" /><line
+   style="fill:none;stroke:#000000;stroke-width:2"
+   id="line10"
+   y2="160"
+   x2="353"
+   y1="160"
+   x1="279" /><line
+   style="fill:none;stroke:#000000;stroke-width:2;stroke-opacity:1"
+   id="line12"
+   y2="172"
+   x2="353"
+   y1="172"
+   x1="279" /><rect
+   style="fill:#f7f7f7;fill-opacity:1"
+   id="rect14"
+   height="128"
+   width="100"
+   y="43"
+   x="33" /><rect
+   style="fill:none;stroke:#85888d;stroke-width:2"
+   id="rect16"
+   height="128"
+   width="100"
+   y="43"
+   x="33" /><line
+   style="fill:none;stroke:#000000;stroke-width:2"
+   id="line18"
+   y2="63"
+   x2="120"
+   y1="63"
+   x1="46" /><line
+   style="fill:none;stroke:#f1a340;stroke-width:2;stroke-opacity:1"
+   id="line20"
+   y2="69"
+   x2="120"
+   y1="69"
+   x1="46" /><line
+   style="fill:none;stroke:#000000;stroke-width:2"
+   id="line22"
+   y2="75"
+   x2="120"
+   y1="75"
+   x1="46" /><line
+   style="fill:none;stroke:#000000;stroke-width:2;stroke-opacity:1"
+   id="line24"
+   y2="87"
+   x2="120"
+   y1="87"
+   x1="46" /><path
+   style="fill:#91bfdb;stroke:#f1a340;stroke-width:2;fill-opacity:1;image-rendering:auto;stroke-opacity:1"
+   d="M 162 155 L 236 155 L 162 155 z "
+   id="line26" />
+
+<polygon
+   fill="#45BEEE"
+   points="205.711,272.768 210.008,286.822 239.666,246.316 192.428,229.32 196.725,243.375 155.825,255.879   164.812,285.271 "
+   id="polygon44"
+   style="fill:#d8daeb;fill-opacity:1" />
+<polygon
+   points="197.488,131.384 193.191,145.438 240.43,128.443 210.771,87.937 206.475,101.992 165.574,89.487   156.588,118.88 "
+   id="polygon46"
+   fill="#45BEEE"
+   style="fill:#d8daeb;fill-opacity:1" />
+<line
+   style="fill:none;stroke:#998ec3;stroke-width:2;stroke-opacity:1"
+   id="line50"
+   y2="208"
+   x2="236"
+   y1="208"
+   x1="162" /><line
+   style="fill:none;stroke:#998ec3;stroke-width:2;stroke-opacity:1"
+   id="line52"
+   y2="214"
+   x2="236"
+   y1="214"
+   x1="162" /><line
+   style="fill:none;stroke:#998ec3;stroke-width:2;stroke-opacity:1"
+   id="line54"
+   y2="179"
+   x2="353"
+   y1="179"
+   x1="279" /><line
+   style="fill:none;stroke:#998ec3;stroke-width:2;stroke-opacity:1"
+   id="line56"
+   y2="185"
+   x2="353"
+   y1="185"
+   x1="279" />
+<path
+   style="fill:#91bfdb;fill-opacity:0;stroke:#91bfdb;stroke-width:0.20233051;stroke-opacity:0"
+   d="m 180.56518,155.88555 c 10.21893,-0.029 26.88085,-0.029 37.02648,1e-5 10.14564,0.029 1.78469,0.0527 -18.57987,0.0527 -20.36457,0 -28.66554,-0.0237 -18.44661,-0.0527 z"
+   id="path4594"
+   inkscape:connector-curvature="0" /><path
+   style="fill:#91bfdb;fill-opacity:0;stroke:#91bfdb;stroke-width:0.20233051;stroke-opacity:0"
+   d="m 162.08647,154.92447 v -0.91049 h 36.92532 36.92532 v 0.91049 0.91049 h -36.92532 -36.92532 z"
+   id="path4598"
+   inkscape:connector-curvature="0" /><rect
+   style="fill:#f7f7f7;fill-opacity:1;stroke:#fc8d59;stroke-opacity:1"
+   id="rect2-3"
+   height="127"
+   width="100"
+   y="221"
+   x="33" /><rect
+   style="fill:none;stroke:#85888d;stroke-width:2"
+   id="rect4-6"
+   height="127"
+   width="100"
+   y="221"
+   x="33" /><line
+   style="fill:none;stroke:#000000;stroke-width:2"
+   id="line6-7"
+   y2="241"
+   x2="120"
+   y1="241"
+   x1="46" /><line
+   style="fill:none;stroke:#000000;stroke-width:2;stroke-opacity:1"
+   id="line8-5"
+   y2="247"
+   x2="120"
+   y1="247"
+   x1="46" /><line
+   style="fill:none;stroke:#000000;stroke-width:2"
+   id="line10-3"
+   y2="252"
+   x2="120"
+   y1="252"
+   x1="46" /><line
+   style="fill:none;stroke:#000000;stroke-width:2;stroke-opacity:1"
+   id="line12-5"
+   y2="264"
+   x2="120"
+   y1="264"
+   x1="46" /><line
+   style="fill:none;stroke:#998ec3;stroke-width:2;stroke-opacity:1"
+   id="line54-6"
+   y2="271"
+   x2="120"
+   y1="271"
+   x1="46" /><line
+   style="fill:none;stroke:#998ec3;stroke-width:2;stroke-opacity:1"
+   id="line56-2"
+   y2="277"
+   x2="120"
+   y1="277"
+   x1="46" /></svg>

--- a/fig/play-changes.svg
+++ b/fig/play-changes.svg
@@ -1,117 +1,473 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="615px"
-	 height="196.5px" viewBox="0 0 615 196.5" enable-background="new 0 0 615 196.5" xml:space="preserve">
-<g id="Layer_1">
-	<g>
-		<defs>
-			<rect id="SVGID_1_" x="34.52" y="28.419" width="104" height="131.217"/>
-		</defs>
-		<clipPath id="SVGID_2_">
-			<use xlink:href="#SVGID_1_"  overflow="visible"/>
-		</clipPath>
-		<rect x="37" y="30" clip-path="url(#SVGID_2_)" fill="#DCDEE0" width="100" height="128"/>
-		<rect x="37" y="30" clip-path="url(#SVGID_2_)" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-	</g>
-	<g>
-		<defs>
-			<rect id="SVGID_3_" x="48.635" y="48.268" width="75.805" height="4"/>
-		</defs>
-		<clipPath id="SVGID_4_">
-			<use xlink:href="#SVGID_3_"  overflow="visible"/>
-		</clipPath>
-		<line clip-path="url(#SVGID_4_)" fill="none" stroke="#000000" stroke-width="2" x1="50" y1="50" x2="123" y2="50"/>
-	</g>
-	<g>
-		<defs>
-			<rect id="SVGID_5_" x="48.635" y="54.097" width="75.805" height="4"/>
-		</defs>
-		<clipPath id="SVGID_6_">
-			<use xlink:href="#SVGID_5_"  overflow="visible"/>
-		</clipPath>
-		<line clip-path="url(#SVGID_6_)" fill="none" stroke="#000000" stroke-width="2" x1="50" y1="56" x2="123" y2="56"/>
-	</g>
-	<g>
-		<defs>
-			<rect id="SVGID_7_" x="48.635" y="59.926" width="75.805" height="4"/>
-		</defs>
-		<clipPath id="SVGID_8_">
-			<use xlink:href="#SVGID_7_"  overflow="visible"/>
-		</clipPath>
-		<line clip-path="url(#SVGID_8_)" fill="none" stroke="#000000" stroke-width="2" x1="50" y1="62" x2="123" y2="62"/>
-	</g>
-	<g>
-		<defs>
-			<rect id="SVGID_9_" x="48.635" y="71.585" width="75.805" height="4"/>
-		</defs>
-		<clipPath id="SVGID_10_">
-			<use xlink:href="#SVGID_9_"  overflow="visible"/>
-		</clipPath>
-		<line clip-path="url(#SVGID_10_)" fill="none" stroke="#000000" stroke-width="2" x1="50" y1="74" x2="123" y2="74"/>
-	</g>
-	<g>
-		<rect x="258" y="30" fill="#DCDEE0" width="100" height="128"/>
-		<rect x="258" y="30" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-		<line fill="none" stroke="#000000" stroke-width="2" x1="272" y1="50" x2="345" y2="50"/>
-		<line fill="none" stroke="#000000" stroke-width="2" x1="272" y1="56" x2="345" y2="56"/>
-		<line fill="none" stroke="#000000" stroke-width="2" x1="272" y1="62" x2="345" y2="62"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="272" y1="74" x2="345" y2="74"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="160" y1="55" x2="234" y2="55"/>
-		<rect x="481" y="31" fill="#DCDEE0" width="100" height="128"/>
-		<rect x="481" y="31" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-		<line fill="none" stroke="#000000" stroke-width="2" x1="495" y1="51" x2="568" y2="51"/>
-		<line fill="none" stroke="#000000" stroke-width="2" x1="495" y1="57" x2="568" y2="57"/>
-		<line fill="none" stroke="#000000" stroke-width="2" x1="495" y1="63" x2="568" y2="63"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="495" y1="75" x2="568" y2="75"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="495" y1="86" x2="568" y2="86"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="495" y1="92" x2="568" y2="92"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="495" y1="98" x2="568" y2="98"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="383" y1="49" x2="457" y2="49"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="383" y1="55" x2="457" y2="55"/>
-		<line fill="none" stroke="#70BF41" stroke-width="2" x1="383" y1="61" x2="457" y2="61"/>
-		<g>
-			<defs>
-				<rect id="SVGID_11_" x="157.116" y="65.521" width="88.974" height="66.13"/>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   width="615px"
+   height="196.5px"
+   viewBox="0 0 615 196.5"
+   enable-background="new 0 0 615 196.5"
+   xml:space="preserve"
+   id="svg979"
+   sodipodi:docname="play-changes.svg"
+   inkscape:version="0.92.4 (unknown)"><metadata
+   id="metadata985"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs983">
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+		
+	</defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1133"
+   id="namedview981"
+   showgrid="false"
+   inkscape:zoom="1.4809"
+   inkscape:cx="218.68789"
+   inkscape:cy="96.340062"
+   inkscape:window-x="1920"
+   inkscape:window-y="38"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg979" />
+<g
+   id="g937">
+			<defs
+   id="defs932">
+				<rect
+   id="SVGID_11_"
+   x="157.116"
+   y="65.521004"
+   width="88.973999"
+   height="66.129997" />
 			</defs>
-			<clipPath id="SVGID_12_">
-				<use xlink:href="#SVGID_11_"  overflow="visible"/>
+			<clipPath
+   id="SVGID_12_">
+				<use
+   xlink:href="#SVGID_11_"
+   overflow="visible"
+   id="use934"
+   style="overflow:visible"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+			</clipPath>
+		</g><g
+   id="g949">
+		<g
+   id="g947">
+			<defs
+   id="defs942">
+				<rect
+   height="768"
+   width="1024"
+   y="-477"
+   x="-203"
+   id="SVGID_13_" />
+			</defs>
+			<clipPath
+   id="SVGID_14_">
+				<use
+   height="100%"
+   width="100%"
+   y="0"
+   x="0"
+   style="overflow:visible"
+   id="use944"
+   overflow="visible"
+   xlink:href="#SVGID_13_" />
 			</clipPath>
 		</g>
-	</g>
-	<g>
-		<g>
-			<defs>
-				<rect id="SVGID_13_" x="-203" y="-477" width="1024" height="768"/>
+	</g><g
+   id="g959">
+		<g
+   id="g957">
+			<defs
+   id="defs952">
+				<rect
+   height="66.128998"
+   width="88.973999"
+   y="73.597"
+   x="375.49399"
+   id="SVGID_15_" />
 			</defs>
-			<clipPath id="SVGID_14_">
-				<use xlink:href="#SVGID_13_"  overflow="visible"/>
+			<clipPath
+   id="SVGID_16_">
+				<use
+   height="100%"
+   width="100%"
+   y="0"
+   x="0"
+   style="overflow:visible"
+   id="use954"
+   overflow="visible"
+   xlink:href="#SVGID_15_" />
 			</clipPath>
 		</g>
-	</g>
-	<g>
-		<g>
-			<defs>
-				<rect id="SVGID_15_" x="375.494" y="73.597" width="88.974" height="66.129"/>
-			</defs>
-			<clipPath id="SVGID_16_">
-				<use xlink:href="#SVGID_15_"  overflow="visible"/>
-			</clipPath>
+	</g><g
+   id="g1004"><g
+     style="fill:#f7f7f7;fill-opacity:1"
+     id="g851">
+		<defs
+   id="defs842">
+			<rect
+   id="SVGID_1_"
+   x="34.52"
+   y="28.419001"
+   width="104"
+   height="131.217" />
+		</defs>
+		<clipPath
+   id="SVGID_2_">
+			<use
+   xlink:href="#SVGID_1_"
+   overflow="visible"
+   id="use844"
+   style="overflow:visible"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<rect
+   x="37"
+   y="30"
+   clip-path="url(#SVGID_2_)"
+   width="100"
+   height="128"
+   id="rect847"
+   style="fill:#f7f7f7;fill-opacity:1" />
+		<rect
+   x="37"
+   y="30"
+   clip-path="url(#SVGID_2_)"
+   width="100"
+   height="128"
+   id="rect849"
+   style="fill:#f7f7f7;fill-opacity:1;stroke:#85888d;stroke-width:2" />
+	</g><g
+     id="g861">
+		<defs
+   id="defs854">
+			<rect
+   id="SVGID_3_"
+   x="48.634998"
+   y="48.268002"
+   width="75.805"
+   height="4" />
+		</defs>
+		<clipPath
+   id="SVGID_4_">
+			<use
+   xlink:href="#SVGID_3_"
+   overflow="visible"
+   id="use856"
+   style="overflow:visible"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<line
+   clip-path="url(#SVGID_4_)"
+   x1="50"
+   y1="50"
+   x2="123"
+   y2="50"
+   id="line859"
+   style="fill:none;stroke:#000000;stroke-width:2" />
+	</g><g
+     id="g871">
+		<defs
+   id="defs864">
+			<rect
+   id="SVGID_5_"
+   x="48.634998"
+   y="54.097"
+   width="75.805"
+   height="4" />
+		</defs>
+		<clipPath
+   id="SVGID_6_">
+			<use
+   xlink:href="#SVGID_5_"
+   overflow="visible"
+   id="use866"
+   style="overflow:visible"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<line
+   clip-path="url(#SVGID_6_)"
+   x1="50"
+   y1="56"
+   x2="123"
+   y2="56"
+   id="line869"
+   style="fill:none;stroke:#000000;stroke-width:2" />
+	</g><g
+     id="g881">
+		<defs
+   id="defs874">
+			<rect
+   id="SVGID_7_"
+   x="48.634998"
+   y="59.925999"
+   width="75.805"
+   height="4" />
+		</defs>
+		<clipPath
+   id="SVGID_8_">
+			<use
+   xlink:href="#SVGID_7_"
+   overflow="visible"
+   id="use876"
+   style="overflow:visible"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<line
+   clip-path="url(#SVGID_8_)"
+   x1="50"
+   y1="62"
+   x2="123"
+   y2="62"
+   id="line879"
+   style="fill:none;stroke:#000000;stroke-width:2" />
+	</g><g
+     id="g891">
+		<defs
+   id="defs884">
+			<rect
+   id="SVGID_9_"
+   x="48.634998"
+   y="71.584999"
+   width="75.805"
+   height="4" />
+		</defs>
+		<clipPath
+   id="SVGID_10_">
+			<use
+   xlink:href="#SVGID_9_"
+   overflow="visible"
+   id="use886"
+   style="overflow:visible"
+   x="0"
+   y="0"
+   width="100%"
+   height="100%" />
+		</clipPath>
+		<line
+   clip-path="url(#SVGID_10_)"
+   x1="50"
+   y1="74"
+   x2="123"
+   y2="74"
+   id="line889"
+   style="fill:none;stroke:#000000;stroke-width:2" />
+	</g><rect
+     style="fill:#f7f7f7;fill-opacity:1"
+     id="rect893"
+     height="128"
+     width="100"
+     y="30"
+     x="258" /><rect
+     style="fill:none;stroke:#85888d;stroke-width:2"
+     id="rect895"
+     height="128"
+     width="100"
+     y="30"
+     x="258" /><line
+     style="fill:none;stroke:#000000;stroke-width:2"
+     id="line897"
+     y2="50"
+     x2="345"
+     y1="50"
+     x1="272" /><line
+     style="fill:none;stroke:#000000;stroke-width:2"
+     id="line899"
+     y2="56"
+     x2="345"
+     y1="56"
+     x1="272" /><line
+     style="fill:none;stroke:#000000;stroke-width:2"
+     id="line901"
+     y2="62"
+     x2="345"
+     y1="62"
+     x1="272" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line903"
+     y2="74"
+     x2="345"
+     y1="74"
+     x1="272" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line905"
+     y2="55"
+     x2="234"
+     y1="55"
+     x1="160" /><rect
+     style="fill:#f7f7f7;fill-opacity:1"
+     id="rect907"
+     height="128"
+     width="100"
+     y="31"
+     x="481" /><rect
+     style="fill:none;stroke:#85888d;stroke-width:2"
+     id="rect909"
+     height="128"
+     width="100"
+     y="31"
+     x="481" /><line
+     style="fill:none;stroke:#000000;stroke-width:2"
+     id="line911"
+     y2="51"
+     x2="568"
+     y1="51"
+     x1="495" /><line
+     style="fill:none;stroke:#000000;stroke-width:2"
+     id="line913"
+     y2="57"
+     x2="568"
+     y1="57"
+     x1="495" /><line
+     style="fill:none;stroke:#000000;stroke-width:2"
+     id="line915"
+     y2="63"
+     x2="568"
+     y1="63"
+     x1="495" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line917"
+     y2="75"
+     x2="568"
+     y1="75"
+     x1="495" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line919"
+     y2="86"
+     x2="568"
+     y1="86"
+     x1="495" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line921"
+     y2="92"
+     x2="568"
+     y1="92"
+     x1="495" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line923"
+     y2="98"
+     x2="568"
+     y1="98"
+     x1="495" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line925"
+     y2="49"
+     x2="457"
+     y1="49"
+     x1="383" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line927"
+     y2="55"
+     x2="457"
+     y1="55"
+     x1="383" /><line
+     style="fill:#998ec3;stroke:#f1a340;stroke-width:2"
+     id="line929"
+     y2="61"
+     x2="457"
+     y1="61"
+     x1="383" /><g
+     id="g967"
+     style="opacity:1;fill:#d8daeb">
+		<rect
+   x="163.931"
+   y="85.276001"
+   width="44.865002"
+   height="26.919001"
+   id="rect961"
+   style="fill:#d8daeb" />
+		<g
+   style="fill:#d8daeb"
+   id="g965">
+			<polygon
+   points="239.275,98.588 200.941,71.743 200.941,125.429 "
+   id="polygon963"
+   style="fill:#d8daeb" />
 		</g>
-	</g>
-	<g opacity="0.5">
-		<rect x="163.931" y="85.276" fill="#009CFD" width="44.865" height="26.919"/>
-		<g>
-			<polygon fill="#009CFD" points="200.941,125.429 239.275,98.588 200.941,71.743 			"/>
+	</g><g
+     id="g975"
+     style="opacity:1;fill:#d8daeb">
+		<rect
+   x="383.01599"
+   y="85.276001"
+   width="44.865002"
+   height="26.919001"
+   id="rect969"
+   style="fill:#d8daeb" />
+		<g
+   style="fill:#d8daeb"
+   id="g973">
+			<polygon
+   points="458.359,98.588 420.026,71.743 420.026,125.429 "
+   id="polygon971"
+   style="fill:#d8daeb" />
 		</g>
-	</g>
-	<g opacity="0.5">
-		<rect x="383.016" y="85.276" fill="#009CFD" width="44.865" height="26.919"/>
-		<g>
-			<polygon fill="#009CFD" points="420.026,125.429 458.359,98.588 420.026,71.743 			"/>
-		</g>
-	</g>
-</g>
-<g id="Layer_2">
+	</g></g>
+<g
+   id="Layer_2">
 </g>
 </svg>

--- a/fig/versions.svg
+++ b/fig/versions.svg
@@ -1,184 +1,539 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="384px" height="354px" viewBox="0 0 384 354" enable-background="new 0 0 384 354" xml:space="preserve">
-<g>
-	<defs>
-		<rect id="SVGID_1_" x="31.218" y="108.841" width="104" height="131.216"/>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="384px"
+   height="354px"
+   viewBox="0 0 384 354"
+   enable-background="new 0 0 384 354"
+   xml:space="preserve"
+   sodipodi:docname="versions.svg"
+   inkscape:version="0.92.4 (unknown)"><metadata
+   id="metadata207"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs205" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1133"
+   id="namedview203"
+   showgrid="false"
+   inkscape:zoom="1.8856181"
+   inkscape:cx="159.99821"
+   inkscape:cy="193.0798"
+   inkscape:window-x="1920"
+   inkscape:window-y="38"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1"><inkscape:grid
+     type="xygrid"
+     id="grid1034" /></sodipodi:namedview>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<g
+   id="g992"><g
+     style="fill:#f7f7f7"
+     id="g12">
+	<defs
+   id="defs3">
+		<rect
+   height="131.216"
+   width="104"
+   y="108.841"
+   x="31.218"
+   id="SVGID_1_" />
 	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_2_">
+		<use
+   id="use5"
+   overflow="visible"
+   xlink:href="#SVGID_1_" />
 	</clipPath>
-	<rect x="33" y="111" clip-path="url(#SVGID_2_)" fill="#DCDEE0" width="100" height="127"/>
-	<rect x="33" y="111" clip-path="url(#SVGID_2_)" fill="none" stroke="#85888D" stroke-width="2" width="100" height="127"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_3_" x="45.334" y="128.688" width="75.805" height="4"/>
+	<rect
+   style="fill:#f7f7f7"
+   id="rect8"
+   height="127"
+   width="100"
+   fill="#DCDEE0"
+   clip-path="url(#SVGID_2_)"
+   y="111"
+   x="33" />
+	<rect
+   style="fill:#f7f7f7"
+   id="rect10"
+   height="127"
+   width="100"
+   stroke-width="2"
+   stroke="#85888D"
+   fill="none"
+   clip-path="url(#SVGID_2_)"
+   y="111"
+   x="33" />
+</g><g
+     id="g22">
+	<defs
+   id="defs15">
+		<rect
+   height="4"
+   width="75.805"
+   y="128.688"
+   x="45.334"
+   id="SVGID_3_" />
 	</defs>
-	<clipPath id="SVGID_4_">
-		<use xlink:href="#SVGID_3_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_4_">
+		<use
+   id="use17"
+   overflow="visible"
+   xlink:href="#SVGID_3_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_4_)" fill="none" stroke="#000000" stroke-width="2" x1="46" y1="131" x2="120" y2="131"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_5_" x="45.334" y="134.519" width="75.805" height="4"/>
+	<line
+   id="line20"
+   y2="131"
+   x2="120"
+   y1="131"
+   x1="46"
+   stroke-width="2"
+   stroke="#000000"
+   fill="none"
+   clip-path="url(#SVGID_4_)" />
+</g><g
+     id="g32">
+	<defs
+   id="defs25">
+		<rect
+   height="4"
+   width="75.805"
+   y="134.519"
+   x="45.334"
+   id="SVGID_5_" />
 	</defs>
-	<clipPath id="SVGID_6_">
-		<use xlink:href="#SVGID_5_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_6_">
+		<use
+   id="use27"
+   overflow="visible"
+   xlink:href="#SVGID_5_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_6_)" fill="none" stroke="#000000" stroke-width="2" x1="46" y1="137" x2="120" y2="137"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_7_" x="45.334" y="140.348" width="75.805" height="4"/>
+	<line
+   id="line30"
+   y2="137"
+   x2="120"
+   y1="137"
+   x1="46"
+   stroke-width="2"
+   stroke="#000000"
+   fill="none"
+   clip-path="url(#SVGID_6_)" />
+</g><g
+     id="g42">
+	<defs
+   id="defs35">
+		<rect
+   height="4"
+   width="75.805"
+   y="140.348"
+   x="45.334"
+   id="SVGID_7_" />
 	</defs>
-	<clipPath id="SVGID_8_">
-		<use xlink:href="#SVGID_7_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_8_">
+		<use
+   id="use37"
+   overflow="visible"
+   xlink:href="#SVGID_7_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_8_)" fill="none" stroke="#000000" stroke-width="2" x1="46" y1="142" x2="120" y2="142"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_9_" x="45.334" y="152.006" width="75.805" height="4"/>
+	<line
+   id="line40"
+   y2="142"
+   x2="120"
+   y1="142"
+   x1="46"
+   stroke-width="2"
+   stroke="#000000"
+   fill="none"
+   clip-path="url(#SVGID_8_)" />
+</g><g
+     id="g52">
+	<defs
+   id="defs45">
+		<rect
+   height="4"
+   width="75.805"
+   y="152.006"
+   x="45.334"
+   id="SVGID_9_" />
 	</defs>
-	<clipPath id="SVGID_10_">
-		<use xlink:href="#SVGID_9_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_10_">
+		<use
+   id="use47"
+   overflow="visible"
+   xlink:href="#SVGID_9_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_10_)" fill="none" stroke="#000000" stroke-width="2" x1="46" y1="154" x2="120" y2="154"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_11_" x="253.198" y="21.402" width="104" height="131.216"/>
+	<line
+   id="line50"
+   y2="154"
+   x2="120"
+   y1="154"
+   x1="46"
+   stroke-width="2"
+   stroke="#000000"
+   fill="none"
+   clip-path="url(#SVGID_10_)" />
+</g><g
+     transform="translate(2.802002,1.3819885)"
+     style="fill:#f7f7f7"
+     id="g64">
+	<defs
+   id="defs55">
+		<rect
+   height="131.216"
+   width="104"
+   y="21.402"
+   x="253.198"
+   id="SVGID_11_" />
 	</defs>
-	<clipPath id="SVGID_12_">
-		<use xlink:href="#SVGID_11_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_12_">
+		<use
+   height="100%"
+   width="100%"
+   y="0"
+   x="0"
+   style="overflow:visible"
+   id="use57"
+   overflow="visible"
+   xlink:href="#SVGID_11_" />
 	</clipPath>
-	<rect x="255" y="23" clip-path="url(#SVGID_12_)" fill="#DCDEE0" width="100" height="128"/>
-	<rect x="255" y="23" clip-path="url(#SVGID_12_)" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_13_" x="267.314" y="41.25" width="75.805" height="4"/>
+	<rect
+   style="fill:#f7f7f7"
+   id="rect60"
+   height="128"
+   width="100"
+   clip-path="url(#SVGID_12_)"
+   y="23"
+   x="255" />
+	<rect
+   style="fill:#f7f7f7;stroke:#85888d;stroke-width:2"
+   id="rect62"
+   height="128"
+   width="100"
+   clip-path="url(#SVGID_12_)"
+   y="23"
+   x="255" />
+</g><g
+     transform="translate(2.802002,1.3819885)"
+     id="g74">
+	<defs
+   id="defs67">
+		<rect
+   height="4"
+   width="75.805"
+   y="41.25"
+   x="267.314"
+   id="SVGID_13_" />
 	</defs>
-	<clipPath id="SVGID_14_">
-		<use xlink:href="#SVGID_13_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_14_">
+		<use
+   height="100%"
+   width="100%"
+   y="0"
+   x="0"
+   style="overflow:visible"
+   id="use69"
+   overflow="visible"
+   xlink:href="#SVGID_13_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_14_)" fill="none" stroke="#000000" stroke-width="2" x1="268" y1="43" x2="342" y2="43"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_15_" x="267.314" y="47.08" width="75.805" height="4"/>
+	<line
+   style="fill:none;stroke:#000000;stroke-width:2"
+   id="line72"
+   y2="43"
+   x2="342"
+   y1="43"
+   x1="268"
+   clip-path="url(#SVGID_14_)" />
+</g><g
+     transform="translate(2.802002,1.3819885)"
+     style="stroke:#f1a340;fill:#f1a340"
+     id="g84">
+	<defs
+   id="defs77">
+		<rect
+   height="4"
+   width="75.805"
+   y="47.080002"
+   x="267.314"
+   id="SVGID_15_" />
 	</defs>
-	<clipPath id="SVGID_16_">
-		<use xlink:href="#SVGID_15_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_16_">
+		<use
+   height="100%"
+   width="100%"
+   y="0"
+   x="0"
+   style="overflow:visible"
+   id="use79"
+   overflow="visible"
+   xlink:href="#SVGID_15_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_16_)" fill="none" stroke="#000000" stroke-width="2" x1="268" y1="49" x2="342" y2="49"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_17_" x="267.314" y="52.909" width="75.805" height="4"/>
+	<line
+   style="fill:#f1a340;stroke:#f1a340;stroke-width:2"
+   id="line82"
+   y2="49"
+   x2="342"
+   y1="49"
+   x1="268"
+   clip-path="url(#SVGID_16_)" />
+</g><g
+     transform="translate(2.802002,1.3819885)"
+     id="g94">
+	<defs
+   id="defs87">
+		<rect
+   height="4"
+   width="75.805"
+   y="52.909"
+   x="267.314"
+   id="SVGID_17_" />
 	</defs>
-	<clipPath id="SVGID_18_">
-		<use xlink:href="#SVGID_17_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_18_">
+		<use
+   height="100%"
+   width="100%"
+   y="0"
+   x="0"
+   style="overflow:visible"
+   id="use89"
+   overflow="visible"
+   xlink:href="#SVGID_17_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_18_)" fill="none" stroke="#000000" stroke-width="2" x1="268" y1="55" x2="342" y2="55"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_19_" x="267.314" y="64.567" width="75.805" height="4"/>
+	<line
+   style="fill:none;stroke:#000000;stroke-width:2"
+   id="line92"
+   y2="55"
+   x2="342"
+   y1="55"
+   x1="268"
+   clip-path="url(#SVGID_18_)" />
+</g><g
+     transform="translate(2.802002,1.3819885)"
+     style="stroke:#00000f;stroke-opacity:0.94117647"
+     id="g104">
+	<defs
+   id="defs97">
+		<rect
+   height="4"
+   width="75.805"
+   y="64.567001"
+   x="267.314"
+   id="SVGID_19_" />
 	</defs>
-	<clipPath id="SVGID_20_">
-		<use xlink:href="#SVGID_19_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_20_">
+		<use
+   height="100%"
+   width="100%"
+   y="0"
+   x="0"
+   style="overflow:visible"
+   id="use99"
+   overflow="visible"
+   xlink:href="#SVGID_19_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_20_)" fill="none" stroke="#70BF41" stroke-width="2" x1="268" y1="67" x2="342" y2="67"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_21_" x="155.796" y="57.292" width="75.806" height="4"/>
+	<line
+   style="fill:none;stroke:#00000f;stroke-width:2;stroke-opacity:0.94117647"
+   id="line102"
+   y2="67"
+   x2="342"
+   y1="67"
+   x1="268"
+   clip-path="url(#SVGID_20_)" />
+</g><g
+     style="stroke:#f1a340;fill:#f1a340"
+     id="g114">
+	<defs
+   id="defs107">
+		<rect
+   height="4"
+   width="75.806"
+   y="57.292"
+   x="155.796"
+   id="SVGID_21_" />
 	</defs>
-	<clipPath id="SVGID_22_">
-		<use xlink:href="#SVGID_21_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_22_">
+		<use
+   id="use109"
+   overflow="visible"
+   xlink:href="#SVGID_21_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_22_)" fill="none" stroke="#70BF41" stroke-width="2" x1="157" y1="59" x2="231" y2="59"/>
-</g>
-<polygon fill="#45BEEE" points="203.427,125.067 207.724,139.122 237.382,98.616 190.144,81.62 194.44,95.675 153.541,108.179 
-	162.527,137.571 "/>
-<g>
-	<defs>
-		<rect id="SVGID_23_" x="253.198" y="201.382" width="104" height="131.216"/>
+	<line
+   style="stroke:#f1a340;fill:#f1a340"
+   id="line112"
+   y2="59"
+   x2="231"
+   y1="59"
+   x1="157"
+   stroke-width="2"
+   stroke="#70BF41"
+   fill="none"
+   clip-path="url(#SVGID_22_)" />
+</g><polygon
+     style="fill:#d8daeb;stroke:#d8daeb"
+     id="polygon116"
+     points="203.427,125.067 207.724,139.122 237.382,98.616 190.144,81.62 194.44,95.675 153.541,108.179   162.527,137.571 "
+     fill="#45BEEE" /><polygon
+     style="fill:#d8daeb;stroke:#d8daeb"
+     id="polygon170"
+     points="194.44,238.713 190.144,252.767 237.382,235.771 207.724,195.266 203.427,209.32 162.527,196.815   153.541,226.208 "
+     fill="#45BEEE" /><g
+     style="stroke:#998ec3;fill:#998ec3"
+     id="g190">
+	<defs
+   id="defs183">
+		<rect
+   height="4"
+   width="75.806"
+   y="265.692"
+   x="156.559"
+   id="SVGID_35_" />
 	</defs>
-	<clipPath id="SVGID_24_">
-		<use xlink:href="#SVGID_23_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_36_">
+		<use
+   id="use185"
+   overflow="visible"
+   xlink:href="#SVGID_35_" />
 	</clipPath>
-	<rect x="255" y="203" clip-path="url(#SVGID_24_)" fill="#DCDEE0" width="100" height="128"/>
-	<rect x="255" y="203" clip-path="url(#SVGID_24_)" fill="none" stroke="#85888D" stroke-width="2" width="100" height="128"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_25_" x="267.314" y="221.229" width="75.805" height="4"/>
+	<line
+   style="stroke:#998ec3;fill:#998ec3"
+   id="line188"
+   y2="268"
+   x2="231"
+   y1="268"
+   x1="158"
+   stroke-width="2"
+   stroke="#C82506"
+   fill="none"
+   clip-path="url(#SVGID_36_)" />
+</g><g
+     style="stroke:#998ec3;fill:#998ec3"
+     id="g200">
+	<defs
+   id="defs193">
+		<rect
+   height="4"
+   width="75.806"
+   y="271.692"
+   x="156.559"
+   id="SVGID_37_" />
 	</defs>
-	<clipPath id="SVGID_26_">
-		<use xlink:href="#SVGID_25_"  overflow="visible"/>
+	<clipPath
+   id="SVGID_38_">
+		<use
+   id="use195"
+   overflow="visible"
+   xlink:href="#SVGID_37_" />
 	</clipPath>
-	<line clip-path="url(#SVGID_26_)" fill="none" stroke="#000000" stroke-width="2" x1="268" y1="223" x2="342" y2="223"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_27_" x="267.314" y="227.059" width="75.805" height="4"/>
-	</defs>
-	<clipPath id="SVGID_28_">
-		<use xlink:href="#SVGID_27_"  overflow="visible"/>
-	</clipPath>
-	<line clip-path="url(#SVGID_28_)" fill="none" stroke="#000000" stroke-width="2" x1="268" y1="229" x2="342" y2="229"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_29_" x="267.314" y="232.888" width="75.805" height="4"/>
-	</defs>
-	<clipPath id="SVGID_30_">
-		<use xlink:href="#SVGID_29_"  overflow="visible"/>
-	</clipPath>
-	<line clip-path="url(#SVGID_30_)" fill="none" stroke="#000000" stroke-width="2" x1="268" y1="235" x2="342" y2="235"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_31_" x="267.314" y="244.547" width="75.805" height="4"/>
-	</defs>
-	<clipPath id="SVGID_32_">
-		<use xlink:href="#SVGID_31_"  overflow="visible"/>
-	</clipPath>
-	<line clip-path="url(#SVGID_32_)" fill="none" stroke="#C82506" stroke-width="2" x1="268" y1="247" x2="342" y2="247"/>
-</g>
-<polygon fill="#45BEEE" points="194.44,238.713 190.144,252.767 237.382,235.771 207.724,195.266 203.427,209.32 162.527,196.815 
-	153.541,226.208 "/>
-<g>
-	<defs>
-		<rect id="SVGID_33_" x="267.314" y="250.547" width="75.805" height="4"/>
-	</defs>
-	<clipPath id="SVGID_34_">
-		<use xlink:href="#SVGID_33_"  overflow="visible"/>
-	</clipPath>
-	<line clip-path="url(#SVGID_34_)" fill="none" stroke="#C82506" stroke-width="2" x1="268" y1="253" x2="342" y2="253"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_35_" x="156.559" y="265.692" width="75.806" height="4"/>
-	</defs>
-	<clipPath id="SVGID_36_">
-		<use xlink:href="#SVGID_35_"  overflow="visible"/>
-	</clipPath>
-	<line clip-path="url(#SVGID_36_)" fill="none" stroke="#C82506" stroke-width="2" x1="158" y1="268" x2="231" y2="268"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_37_" x="156.559" y="271.692" width="75.806" height="4"/>
-	</defs>
-	<clipPath id="SVGID_38_">
-		<use xlink:href="#SVGID_37_"  overflow="visible"/>
-	</clipPath>
-	<line clip-path="url(#SVGID_38_)" fill="none" stroke="#C82506" stroke-width="2" x1="158" y1="274" x2="231" y2="274"/>
-</g>
-</svg>
+	<line
+   style="stroke:#998ec3;fill:#998ec3"
+   id="line198"
+   y2="274"
+   x2="231"
+   y1="274"
+   x1="158"
+   stroke-width="2"
+   stroke="#C82506"
+   fill="none"
+   clip-path="url(#SVGID_38_)" />
+</g><rect
+     x="258"
+     y="203"
+     width="100"
+     height="127"
+     id="rect2-3"
+     style="fill:#f7f7f7;fill-opacity:1;stroke:#fc8d59;stroke-opacity:1" /><rect
+     x="258"
+     y="203"
+     width="100"
+     height="127"
+     id="rect4-6"
+     style="fill:none;stroke:#85888d;stroke-width:2" /><line
+     x1="271"
+     y1="223"
+     x2="345"
+     y2="223"
+     id="line6-7"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="271"
+     y1="229"
+     x2="345"
+     y2="229"
+     id="line8-5"
+     style="fill:none;stroke:#000000;stroke-width:2;stroke-opacity:1" /><line
+     x1="271"
+     y1="234"
+     x2="345"
+     y2="234"
+     id="line10-3"
+     style="fill:none;stroke:#000000;stroke-width:2" /><line
+     x1="271"
+     y1="246"
+     x2="345"
+     y2="246"
+     id="line12-5"
+     style="fill:none;stroke:#000000;stroke-width:2;stroke-opacity:1" /><line
+     x1="271"
+     y1="253"
+     x2="345"
+     y2="253"
+     id="line54-6"
+     style="fill:#998ec3;stroke:#998ec3;stroke-width:2;stroke-opacity:1" /><line
+     x1="271"
+     y1="259"
+     x2="345"
+     y2="259"
+     id="line56-2"
+     style="fill:#998ec3;stroke:#998ec3;stroke-width:2;stroke-opacity:1" /></g></svg>


### PR DESCRIPTION
Change the logic of modified rows in figures to comply with the narrative.

Use also a color blind safe color palette:
['#b35806','#f1a340','#fee0b6','#f7f7f7','#d8daeb','#998ec3','#542788']
Generated with: http://colorbrewer2.org/?type=diverging&scheme=PuOr&n=7
This was also referred:
https://github.com/UKHomeOffice/posters/blob/master/accessibility/dos-donts/posters_en-UK/accessibility-posters-set.pdf

Preview:
![update-figures_preview](https://user-images.githubusercontent.com/3051383/73596027-3d238300-4527-11ea-9755-c7cdaab14d45.png)

