### PR TITLE
Change head command option to support macOS

### DIFF
--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -351,7 +351,7 @@ Conflicts can also be minimized with project management strategies:
 > > a dummy binary file like this:
 > >
 > > ~~~
-> > $ head --bytes 1024 /dev/urandom > mars.jpg
+> > $ head -c 1024 /dev/urandom > mars.jpg
 > > $ ls -lh mars.jpg
 > > ~~~
 > > {: .language-bash}


### PR DESCRIPTION
The `head` command on macOS does not recognise the long `--bytes` option.
Update the episode to use the equivalent short option `-c` instead.
