### PR TITLE
Remove confusing `rm` text in episode 3

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -156,26 +156,18 @@ wording of the output might be slightly different.
 >
 > > ## Solution -- USE WITH CAUTION!
 > >
-> > ### Background
-> > Removing files from a git repository needs to be done with caution. To remove files from the working tree and not from your working directory, use
-> > ~~~
-> > $ rm filename
-> > ~~~
-> > {: .language-bash}
-> > 
-> > The file being removed has to be in sync with the branch head with no updates. If there are updates, the file can be removed by force by using the `-f` option. Similarly a directory can be removed from git using `rm -r dirname` or `rm -rf dirname`.
-> >
-> > ### Solution
 > > Git keeps all of its files in the `.git` directory.
 > > To recover from this little mistake, Dracula can just remove the `.git`
-> > folder in the moons subdirectory by running the following command from inside the `planets` directory:
+> > folder for the nested repository in the `moons` subdirectory by running
+> > the following command from inside the `planets` directory:
 > >
 > > ~~~
 > > $ rm -rf moons/.git
 > > ~~~
 > > {: .language-bash}
 > >
-> > But be careful! Running this command in the wrong directory, will remove
+> > But be careful! The `rm` shell command deletes files and directories.
+> > Running this command in the wrong directory, will remove
 > > the entire Git history of a project you might want to keep. Therefore, always check your current directory using the
 > > command `pwd`.
 > {: .solution}


### PR DESCRIPTION
The challenge problem to remove a nested git repository at the end of episode 3 has a confusing solution. It uses the term "working tree" that is not used anywhere else in the course. It discusses "working directory" before that is introduced in episode 4. Furthermore, removing the errant `.git` directory is not the same as "removing files from the repository", and in general an `rm` command will not remove files from the history of a git repository.

Others have also noticed this problem. Among all the changes in #686 there is a similar edit.