### PR TITLE
Fixed the link redirecting to the Git setup page

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -14,4 +14,4 @@ $ cd Desktop
 ~~~
 {: .language-bash}
 
-[workshop-setup]: https://carpentries.github.io/workshop-template/#git
+[workshop-setup]: https://github.com/carpentries/workshop-template/blob/gh-pages/_includes/swc/setup.html


### PR DESCRIPTION
Link was broken, this edit fixes it and redirects the user to the correct Git setup instructions page.