### PR TITLE
Revert "Fixed the link redirecting to the Git setup page"

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -14,4 +14,4 @@ $ cd Desktop
 ~~~
 {: .language-bash}
 
-[workshop-setup]: https://github.com/carpentries/workshop-template/blob/gh-pages/_includes/swc/setup.html
+[workshop-setup]: https://carpentries.github.io/workshop-template/#git


### PR DESCRIPTION
Reverts swcarpentry/git-novice#737. Based on the fix in [d0abde3](https://github.com/carpentries/workshop-template/commit/d0abde30d1e90964dec5df78837e28a0768c2b3f), the original URL of https://carpentries.github.io/workshop-template/#git works, so we can revert PR 737 and transition the setup directions to this repo.

