### PR TITLE
Conflicts: indicate who makes what changes

### DIFF
--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -35,7 +35,7 @@ But the Mummy will appreciate the lack of humidity
 ~~~
 {: .output}
 
-Let's add a line to one partner's copy only:
+Let's add a line to the collaborator's copy only:
 
 ~~~
 $ nano mars.txt
@@ -83,7 +83,7 @@ To https://github.com/vlad/planets.git
 ~~~
 {: .output}
 
-Now let's have the other partner
+Now let's have the owner
 make a different change to their copy
 *without* updating from GitHub:
 


### PR DESCRIPTION
Having the collaborator make the first change puts the responsibility to resolve the conflict with the owner, which makes more sense. I have often seen the reverse scenario during workshops, and then one has to explain that the collaborator needs to contact the owner to discuss how to resolve it, as they are not the original author. It makes more sense to have the original author/owner make the decision how to resolve the conflict.
