### PR TITLE
Update `git status` output

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -93,7 +93,7 @@ $ git status
 ~~~
 On branch master
 
-Initial commit
+No commits yet
 
 nothing to commit (create/copy files and use "git add" to track)
 ~~~

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -80,12 +80,13 @@ $ git status
 ~~~
 On branch master
 
-Initial commit
+No commits yet
 
 Untracked files:
    (use "git add <file>..." to include in what will be committed)
 
 	mars.txt
+
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
 {: .output}
@@ -109,7 +110,7 @@ $ git status
 ~~~
 On branch master
 
-Initial commit
+No commits yet
 
 Changes to be committed:
   (use "git rm --cached <file>..." to unstage)


### PR DESCRIPTION
It seems at some point git changed the output message it gives when the repo doesn't contain any commit yet.

Tested with:
- git 2.17.1 under Linux
- git 2.27 (latest) under Windows
