### PR TITLE
Change `checkout` actions to use newer `restore` syntax

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -282,8 +282,9 @@ If we break it down into pieces:
 2.  The second line tells exactly which versions of the file
     Git is comparing;
     `df0654a` and `315bf3a` are unique computer-generated labels for those versions.
-3.  The `i` and `w` (your version might say `a` and `b` if using an
-    older version of Git) refer to the `index` and `working` copies
+3.  The `i` and `w` (your version might say `a` and `b`
+    depending on settings; see note below) refer to the `index`
+    and `working` copies
     of the files. The "working" version is the one that we have changed,
     while the "index" is the version that Git already knows about.
 4.  The third and fourth lines once again show the name of the file being changed.
@@ -291,6 +292,16 @@ If we break it down into pieces:
     and the lines on which they occur.
     In particular,
     the `+` marker in the first column shows where we added a line.
+
+> ## A note on `diff` output
+>
+> If your `diff.mnemonicPrefix` Git configuration variable
+> is set to false, in place of the `i/` and `w/` prefixes in the
+> `diff` header, you will likely see `a/` and `b/`, which do not
+> have any intrinsic meaning. See the `git-config`
+> [manual page](https://git-scm.com/docs/git-config#Documentation/git-config.txt-diffmnemonicPrefix)
+> for more details.
+{: .callout}
 
 After reviewing our change, it's time to commit it:
 

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -83,9 +83,8 @@ On branch master
 No commits yet
 
 Untracked files:
-   (use "git add <file>..." to include in what will be committed)
-
-	mars.txt
+  (use "git add <file>..." to include in what will be committed)
+        mars.txt
 
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
@@ -114,9 +113,7 @@ No commits yet
 
 Changes to be committed:
   (use "git rm --cached <file>..." to unstage)
-
-	new file:   mars.txt
-
+        new file:   mars.txt
 ~~~
 {: .output}
 
@@ -131,7 +128,7 @@ $ git commit -m "Start notes on Mars as a base"
 {: .language-bash}
 
 ~~~
-[master (root-commit) f22b25e] Start notes on Mars as a base
+[master (root-commit) 097d183] Start notes on Mars as a base
  1 file changed, 1 insertion(+)
  create mode 100644 mars.txt
 ~~~
@@ -141,7 +138,7 @@ When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
 and stores a copy permanently inside the special `.git` directory.
 This permanent copy is called a [commit]({{ page.root }}{% link reference.md %}#commit)
-(or [revision]({{ page.root }}{% link reference.md %}#revision)) and its short identifier is `f22b25e`. Your commit may have another identifier.
+(or [revision]({{ page.root }}{% link reference.md %}#revision)) and its short identifier is `097d183`. Your commit may have another identifier.
 
 We use the `-m` flag (for "message")
 to record a short, descriptive, and specific comment that will help us remember later on what we did and why.
@@ -162,7 +159,7 @@ $ git status
 
 ~~~
 On branch master
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 
@@ -176,9 +173,9 @@ $ git log
 {: .language-bash}
 
 ~~~
-commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
+commit 097d1832c48997a846ee1a0628dc3d68e2f1094f (HEAD -> master)
 Author: Vlad Dracula <vlad@tran.sylvan.ia>
-Date:   Thu Aug 22 09:51:46 2013 -0400
+Date:   Mon Oct 5 16:55:16 2020 -0600
 
     Start notes on Mars as a base
 ~~~
@@ -230,13 +227,23 @@ $ git status
 On branch master
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
-  (use "git checkout -- <file>..." to discard changes in working directory)
-
-	modified:   mars.txt
+  (use "git restore <file>..." to discard changes in working directory)
+        modified:   mars.txt
 
 no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
 {: .output}
+
+> ## Note, new output in `git` version 2.23
+>
+> If you are using a version of Git older than 2.23 (you can check by
+> running `git --version`) you'll probably see `git checkout --` in the above
+> output instead of `git restore`. If so, worry not! It only means that your
+> Git version is slightly out of date, but that's okay, everything will
+> still work and we'll instruct you if you need to change any commands. If
+> your version *is* out of date, please keep this notice in mind throughout
+> the section when comparing your output.
+{: .callout}
 
 The last line is the key phrase:
 "no changes added to commit".
@@ -255,10 +262,10 @@ $ git diff
 {: .language-bash}
 
 ~~~
-diff --git a/mars.txt b/mars.txt
+diff --git i/mars.txt w/mars.txt
 index df0654a..315bf3a 100644
---- a/mars.txt
-+++ b/mars.txt
+--- i/mars.txt
++++ w/mars.txt
 @@ -1 +1,2 @@
  Cold and dry, but everything is my favorite color
 +The two moons may be a problem for Wolfman
@@ -275,8 +282,12 @@ If we break it down into pieces:
 2.  The second line tells exactly which versions of the file
     Git is comparing;
     `df0654a` and `315bf3a` are unique computer-generated labels for those versions.
-3.  The third and fourth lines once again show the name of the file being changed.
-4.  The remaining lines are the most interesting, they show us the actual differences
+3.  The `i` and `w` (your version might say `a` and `b` if using an
+    older version of Git) refer to the `index` and `working` copies
+    of the files. The "working" version is the one that we have changed,
+    while the "index" is the version that Git already knows about.
+4.  The third and fourth lines once again show the name of the file being changed.
+5.  The remaining lines are the most interesting, they show us the actual differences
     and the lines on which they occur.
     In particular,
     the `+` marker in the first column shows where we added a line.
@@ -293,9 +304,8 @@ $ git status
 On branch master
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
-  (use "git checkout -- <file>..." to discard changes in working directory)
-
-	modified:   mars.txt
+  (use "git restore <file>..." to discard changes in working directory)
+        modified:   mars.txt
 
 no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
@@ -312,7 +322,7 @@ $ git commit -m "Add concerns about effects of Mars' moons on Wolfman"
 {: .language-bash}
 
 ~~~
-[master 34961b1] Add concerns about effects of Mars' moons on Wolfman
+[master 3594896] Add concerns about effects of Mars' moons on Wolfman
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
@@ -381,10 +391,10 @@ $ git diff
 {: .language-bash}
 
 ~~~
-diff --git a/mars.txt b/mars.txt
+diff --git i/mars.txt w/mars.txt
 index 315bf3a..b36abfd 100644
---- a/mars.txt
-+++ b/mars.txt
+--- i/mars.txt
++++ w/mars.txt
 @@ -1,2 +1,3 @@
  Cold and dry, but everything is my favorite color
  The two moons may be a problem for Wolfman
@@ -417,10 +427,10 @@ $ git diff --staged
 {: .language-bash}
 
 ~~~
-diff --git a/mars.txt b/mars.txt
+diff --git c/mars.txt i/mars.txt
 index 315bf3a..b36abfd 100644
---- a/mars.txt
-+++ b/mars.txt
+--- c/mars.txt
++++ i/mars.txt
 @@ -1,2 +1,3 @@
  Cold and dry, but everything is my favorite color
  The two moons may be a problem for Wolfman
@@ -439,7 +449,7 @@ $ git commit -m "Discuss concerns about Mars' climate for Mummy"
 {: .language-bash}
 
 ~~~
-[master 005937f] Discuss concerns about Mars' climate for Mummy
+[master 378bb77] Discuss concerns about Mars' climate for Mummy
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
@@ -453,7 +463,7 @@ $ git status
 
 ~~~
 On branch master
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 
@@ -465,21 +475,21 @@ $ git log
 {: .language-bash}
 
 ~~~
-commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
+commit 378bb7742c4bc88b4920aa273c1f4f39bbc4c946 (HEAD -> master)
 Author: Vlad Dracula <vlad@tran.sylvan.ia>
-Date:   Thu Aug 22 10:14:07 2013 -0400
+Date:   Mon Oct 5 17:15:52 2020 -0600
 
     Discuss concerns about Mars' climate for Mummy
 
-commit 34961b159c27df3b475cfe4415d94a6d1fcd064d
+commit 359489683ef4f2c4d81e687cfac2c96623236ed6
 Author: Vlad Dracula <vlad@tran.sylvan.ia>
-Date:   Thu Aug 22 10:07:21 2013 -0400
+Date:   Mon Oct 5 17:13:22 2020 -0600
 
     Add concerns about effects of Mars' moons on Wolfman
 
-commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
+commit 097d1832c48997a846ee1a0628dc3d68e2f1094f
 Author: Vlad Dracula <vlad@tran.sylvan.ia>
-Date:   Thu Aug 22 09:51:46 2013 -0400
+Date:   Mon Oct 5 16:55:16 2020 -0600
 
     Start notes on Mars as a base
 ~~~
@@ -521,11 +531,11 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > {: .language-bash}
 >
 > ~~~
-> commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
+> commit 378bb7742c4bc88b4920aa273c1f4f39bbc4c946 (HEAD -> master)
 > Author: Vlad Dracula <vlad@tran.sylvan.ia>
-> Date:   Thu Aug 22 10:14:07 2013 -0400
->
->    Discuss concerns about Mars' climate for Mummy
+> Date:   Mon Oct 5 17:15:52 2020 -0600
+> 
+>     Discuss concerns about Mars' climate for Mummy
 > ~~~
 > {: .output}
 >
@@ -537,9 +547,9 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > {: .language-bash}
 > ~~~
-> 005937f Discuss concerns about Mars' climate for Mummy
-> 34961b1 Add concerns about effects of Mars' moons on Wolfman
-> f22b25e Start notes on Mars as a base
+> 378bb77 (HEAD -> master) Discuss concerns about Mars' climate for Mummy
+> 3594896 Add concerns about effects of Mars' moons on Wolfman
+> 097d183 Start notes on Mars as a base
 > ~~~
 > {: .output}
 >
@@ -554,9 +564,9 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > {: .language-bash}
 > ~~~
-> * 005937f (HEAD -> master) Discuss concerns about Mars' climate for Mummy
-> * 34961b1 Add concerns about effects of Mars' moons on Wolfman
-> * f22b25e Start notes on Mars as a base
+> * 378bb77 (HEAD -> master) Discuss concerns about Mars' climate for > Mummy
+> * 3594896 Add concerns about effects of Mars' moons on Wolfman
+> * 097d183 Start notes on Mars as a base
 > ~~~
 > {: .output}
 {: .callout}

--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -321,6 +321,9 @@ $ git restore mars.txt   # git checkout HEAD mars.txt
 > This ambiguity with the `checkout` action is part of the reason the
 > `restore` action was introduced (and is the default) in newer
 > versions of Git.
+>
+> If you want to detach the HEAD using the newer syntax, the correct command
+> to use is `git switch --detach <commit ID>`.
 {: .callout}
 
 It's important to remember that if we want to undo a change,

--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -13,7 +13,7 @@ objectives:
 - "Restore old versions of files."
 keypoints:
 - "`git diff` displays differences between commits."
-- "`git checkout` recovers old versions of files."
+- "`git restore` recovers old versions of files."
 ---
 
 As we saw in the previous lesson, we can refer to commits by their
@@ -46,23 +46,26 @@ $ git diff HEAD mars.txt
 {: .language-bash}
 
 ~~~
-diff --git a/mars.txt b/mars.txt
-index b36abfd..0848c8d 100644
---- a/mars.txt
-+++ b/mars.txt
+diff --git c/mars.txt w/mars.txt
+index b36abfd..93a3e13 100644
+--- c/mars.txt
++++ w/mars.txt
 @@ -1,3 +1,4 @@
  Cold and dry, but everything is my favorite color
  The two moons may be a problem for Wolfman
  But the Mummy will appreciate the lack of humidity
-+An ill-considered change.
++An ill-considered change
 ~~~
 {: .output}
 
 which is the same as what you would get if you leave out `HEAD` (try it).  The
 real goodness in all this is when you can refer to previous commits.  We do
 that by adding `~1` 
-(where "~" is "tilde", pronounced [**til**-d*uh*]) 
-to refer to the commit one before `HEAD`.
+(where "~" is "tilde", pronounced [**til**-d*uh*])
+to refer to the commit one before `HEAD`. If you have the
+`diff.mnemonicPrefix` setting enabled, the `diff` prefixes
+in the output will be `c/` and `w/`, referring to the commit
+(referenced with `HEAD`) and working tree, respectively.
 
 ~~~
 $ git diff HEAD~1 mars.txt
@@ -74,15 +77,15 @@ again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to them:
 
 
 ~~~
-$ git diff HEAD~3 mars.txt
+$ git diff HEAD~2 mars.txt
 ~~~
 {: .language-bash}
 
 ~~~
-diff --git a/mars.txt b/mars.txt
-index df0654a..b36abfd 100644
---- a/mars.txt
-+++ b/mars.txt
+diff --git c/mars.txt w/mars.txt
+index df0654a..93a3e13 100644
+--- c/mars.txt
++++ w/mars.txt
 @@ -1 +1,4 @@
  Cold and dry, but everything is my favorite color
 +The two moons may be a problem for Wolfman
@@ -96,14 +99,14 @@ well as the commit message, rather than the _differences_ between a commit and o
 working directory that we see by using `git diff`.
 
 ~~~
-$ git show HEAD~3 mars.txt
+$ git show HEAD~2 mars.txt
 ~~~
 {: .language-bash}
 
 ~~~
-commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
+commit 097d1832c48997a846ee1a0628dc3d68e2f1094f
 Author: Vlad Dracula <vlad@tran.sylvan.ia>
-Date:   Thu Aug 22 09:51:46 2013 -0400
+Date:   Mon Oct 5 16:55:16 2020 -0600
 
     Start notes on Mars as a base
 
@@ -133,19 +136,19 @@ and "unique" really does mean unique:
 every change to any set of files on any computer
 has a unique 40-character identifier.
 Our first commit was given the ID
-`f22b25e3233b4645dabd0d81e651fe074bd8e73b`,
+`097d1832c48997a846ee1a0628dc3d68e2f1094f`,
 so let's try this:
 
 ~~~
-$ git diff f22b25e3233b4645dabd0d81e651fe074bd8e73b mars.txt
+$ git diff 097d1832c48997a846ee1a0628dc3d68e2f1094f mars.txt
 ~~~
 {: .language-bash}
 
 ~~~
-diff --git a/mars.txt b/mars.txt
+diff --git c/mars.txt w/mars.txt
 index df0654a..93a3e13 100644
---- a/mars.txt
-+++ b/mars.txt
+--- c/mars.txt
++++ w/mars.txt
 @@ -1 +1,4 @@
  Cold and dry, but everything is my favorite color
 +The two moons may be a problem for Wolfman
@@ -159,15 +162,15 @@ but typing out random 40-character strings is annoying,
 so Git lets us use just the first few characters (typically seven for normal size projects):
 
 ~~~
-$ git diff f22b25e mars.txt
+$ git diff 097d183 mars.txt
 ~~~
 {: .language-bash}
 
 ~~~
-diff --git a/mars.txt b/mars.txt
+diff --git c/mars.txt w/mars.txt
 index df0654a..93a3e13 100644
---- a/mars.txt
-+++ b/mars.txt
+--- c/mars.txt
++++ w/mars.txt
 @@ -1 +1,4 @@
  Cold and dry, but everything is my favorite color
 +The two moons may be a problem for Wolfman
@@ -194,19 +197,28 @@ $ git status
 On branch master
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
-  (use "git checkout -- <file>..." to discard changes in working directory)
-
-    modified:   mars.txt
+  (use "git restore <file>..." to discard changes in working directory)
+        modified:   mars.txt
 
 no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
 {: .output}
 
+> ## Reminder about change to `checkout` in Git version 2.23
+>
+> Remember, if you are using a version of Git older than 2.23 you'll probably
+> see `git checkout --` in the above output instead of `git restore`. If this
+> is the case, any time you see `git restore` in the below command/output,
+> please use `git checkout --` instead (or whatever command is
+> indicated after the bash comment). For more detail on why this command
+> was changed, please see [this link](https://github.blog/2019-08-16-highlights-from-git-2-23/#experimental-alternatives-for-git-checkout).
+{: .callout}
+
 We can put things back the way they were
-by using `git checkout`:
+by using `git restore`:
 
 ~~~
-$ git checkout HEAD mars.txt
+$ git restore mars.txt   # git checkout HEAD mars.txt
 $ cat mars.txt
 ~~~
 {: .language-bash}
@@ -219,15 +231,14 @@ But the Mummy will appreciate the lack of humidity
 {: .output}
 
 As you might guess from its name,
-`git checkout` checks out (i.e., restores) an old version of a file.
-In this case,
-we're telling Git that we want to recover the version of the file recorded in `HEAD`,
-which is the last saved commit.
-If we want to go back even further,
-we can use a commit identifier instead:
+`git restore` restores an older version of a file.
+In this case, we're telling Git that we want to recover
+the version of the file as it was at the last saved commit.
+If we want to go back even further, we can use a commit
+identifier with the `-s/--source` flag instead:
 
 ~~~
-$ git checkout f22b25e mars.txt
+$ git restore -s 097d183 mars.txt   # git checkout 097d183 mars.txt
 ~~~
 {: .language-bash}
 
@@ -248,43 +259,47 @@ $ git status
 
 ~~~
 On branch master
-Changes to be committed:
-  (use "git reset HEAD <file>..." to unstage)
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+        modified:   mars.txt
 
-    modified:   mars.txt
-
+no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
 {: .output}
 
 Notice that the changes are currently in the staging area.
 Again, we can put things back the way they were
-by using `git checkout`:
+by using `git restore`:
 
 ~~~
-$ git checkout HEAD mars.txt
+$ git restore mars.txt   # git checkout HEAD mars.txt
 ~~~
 {: .language-bash}
 
 > ## Don't Lose Your HEAD
 >
-> Above we used
->
+> This warning only applies if you're using an older version 
+> of Git that relies on the `checkout` action instead of `restore`.
+> Using the command:
 > ~~~
-> $ git checkout f22b25e mars.txt
-> ~~~
-> {: .language-bash}
->
-> to revert `mars.txt` to its state after the commit `f22b25e`. But be careful! 
-> The command `checkout` has other important functionalities and Git will misunderstand
-> your intentions if you are not accurate with the typing. For example, 
-> if you forget `mars.txt` in the previous command.
->
-> ~~~
-> $ git checkout f22b25e
+> $ git checkout 097d183 mars.txt
 > ~~~
 > {: .language-bash}
+>
+> to revert `mars.txt` to its state after the commit `097d183` can
+> be dangerous because the command `checkout` has other
+> functionalities and Git will misunderstand
+> your intentions if you are not accurate with the typing.
+> For example, if you forget `mars.txt` in the previous command,
+> you will enter a "detached HEAD" state, which is not what you want:
+>
 > ~~~
-> Note: checking out 'f22b25e'.
+> $ git checkout 097d183
+> ~~~
+> {: .language-bash}
+> ~~~
+> Note: checking out '097d183'.
 >
 > You are in 'detached HEAD' state. You can look around, make experimental
 > changes and commit them, and you can discard any commits you make in this
@@ -295,22 +310,27 @@ $ git checkout HEAD mars.txt
 >
 >  git checkout -b <new-branch-name>
 >
-> HEAD is now at f22b25e Start notes on Mars as a base
+> HEAD is now at 097d183 Start notes on Mars as a base
 > ~~~
 > {: .error}
 >
-> The "detached HEAD" is like "look, but don't touch" here,
-> so you shouldn't make any changes in this state.
-> After investigating your repo's past state, reattach your `HEAD` with `git checkout master`.
+> The "detached HEAD" state can be thought of as a "look, but
+> don't touch" mode, so you shouldn't make any changes in this state.
+> After investigating your repo's past state, you can reattach your
+> `HEAD` with `git checkout master`.
+> This ambiguity with the `checkout` action is part of the reason the
+> `restore` action was introduced (and is the default) in newer
+> versions of Git.
 {: .callout}
 
-It's important to remember that
-we must use the commit number that identifies the state of the repository
-*before* the change we're trying to undo.
+It's important to remember that if we want to undo a change,
+we must use the commit number that identifies the state of the
+repository *before* the change we're trying to undo.
 A common mistake is to use the number of
 the commit in which we made the change we're trying to discard.
 In the example below, we want to retrieve the state from before the most
-recent commit (`HEAD~1`), which is commit `f22b25e`:
+recent commit (`HEAD~1`), which is commit `f22b25e` (these commit
+IDs are random and not the same as in our example to this point):
 
 ![Git Checkout](../fig/git-checkout.svg)
 
@@ -318,24 +338,6 @@ So, to put it all together,
 here's how Git works in cartoon form:
 
 ![https://figshare.com/articles/How_Git_works_a_cartoon/1328266](../fig/git_staging.svg)
-
-> ## Simplifying the Common Case
->
-> If you read the output of `git status` carefully,
-> you'll see that it includes this hint:
->
-> ~~~
-> (use "git checkout -- <file>..." to discard changes in working directory)
-> ~~~
-> {: .language-bash}
->
-> As it says,
-> `git checkout` without a version identifier restores files to the state saved in `HEAD`.
-> The double dash `--` is needed to separate the names of the files being recovered
-> from the command itself:
-> without it,
-> Git would try to use the name of the file as the commit identifier.
-{: .callout}
 
 The fact that files can be reverted one by one
 tends to change the way people organize their work.
@@ -356,35 +358,31 @@ moving backward and forward in time becomes much easier.
 > let her recover the last committed version of her Python script called
 > `data_cruncher.py`?
 >
-> 1. `$ git checkout HEAD`
+> 1. `$ git restore`
 >
-> 2. `$ git checkout HEAD data_cruncher.py`
+> 2. `$ git restore data_cruncher.py`
 >
-> 3. `$ git checkout HEAD~1 data_cruncher.py`
+> 3. `$ git restore -s HEAD~1 data_cruncher.py`
 >
-> 4. `$ git checkout <unique ID of last commit> data_cruncher.py`
+> 4. `$ git restore -s <unique ID of last commit> data_cruncher.py`
 >
 > 5. Both 2 and 4
 >
 >
 > > ## Solution
 > >
-> > The answer is (5)-Both 2 and 4. 
-> > 
-> > The `checkout` command restores files from the repository, overwriting the files in your working 
-> > directory. Answers 2 and 4 both restore the *latest* version *in the repository* of the file 
-> > `data_cruncher.py`. Answer 2 uses `HEAD` to indicate the *latest*, whereas answer 4 uses the 
-> > unique ID of the last commit, which is what `HEAD` means. 
-> > 
-> > Answer 3 gets the version of `data_cruncher.py` from the commit *before* `HEAD`, which is NOT 
+> > The answer is (5)-Both 2 and 4.
+> >
+> > The `restore` command restores files from the repository, overwriting the files in your working
+> > directory. Answers 2 and 4 both restore the *latest* version *in the repository* of the file
+> > `data_cruncher.py`. Answer 2 uses the default options for `restore` to indicate the *latest* commit, whereas answer 4 uses the
+> > unique ID of the last commit with the `source` option.
+> >
+> > Answer 3 gets the version of `data_cruncher.py` from the commit *before* `HEAD`, which is NOT
 > > what we wanted.
-> > 
-> > Answer 1 can be dangerous! Without a filename, `git checkout` will restore **all files** 
-> > in the current directory (and all directories below it) to their state at the commit specified. 
-> > This command will restore `data_cruncher.py` to the latest commit version, but it will also 
-> > restore *any other files that are changed* to that version, erasing any changes you may 
-> > have made to those files!
-> > As discussed above, you are left in a *detached* `HEAD` state, and you don't want to be there.
+> >
+> > Answer 1 will not work. Without a filename, `git restore` will
+> > complain that you "must specify a path(s) to restore"
 > {: .solution}
 {: .challenge}
 
@@ -392,9 +390,9 @@ moving backward and forward in time becomes much easier.
 >
 > Jennifer is collaborating on her Python script with her colleagues and
 > realizes her last commit to the project's repository contained an error and
-> she wants to undo it.  `git revert [erroneous commit ID]` will create a new 
+> she wants to undo it.  `git revert [erroneous commit ID]` will create a new
 > commit that reverses Jennifer's erroneous commit. Therefore `git revert` is
-> different to `git checkout [commit ID]` because `git checkout` returns the
+> different to `git restore -s [commit ID]` because `git restore` returns the
 > files within the local repository to a previous state, whereas `git revert`
 > reverses changes committed to the local and project repositories.  
 > Below are the right steps and explanations for Jennifer to use `git revert`,
@@ -409,6 +407,11 @@ moving backward and forward in time becomes much easier.
 > 4. Type in the new commit message.
 >
 > 5. Save and close
+>
+> > ## Solution
+> >
+> > The answer is `git log --oneline` (`--oneline` is optional, but makes the output a little easier to read)
+> {: .solution}
 {: .challenge}
 
 > ## Understanding Workflow and History
@@ -421,7 +424,7 @@ moving backward and forward in time becomes much easier.
 > $ git add venus.txt
 > $ echo "Venus is too hot to be suitable as a base" >> venus.txt
 > $ git commit -m "Comment on Venus as an unsuitable base"
-> $ git checkout HEAD venus.txt
+> $ git restore venus.txt
 > $ cat venus.txt #this will print the contents of venus.txt to the screen
 > ~~~
 > {: .language-bash}
@@ -457,7 +460,7 @@ moving backward and forward in time becomes much easier.
 > > has only one line.
 > >  
 > >  At this time, the working copy still has the second line (and 
-> >  `git status` will show that the file is modified). However, `git checkout HEAD venus.txt` 
+> >  `git status` will show that the file is modified). However, `git restore venus.txt`
 > >  replaces the working copy with the most recently committed version of `venus.txt`.
 > >  
 > >  So, `cat venus.txt` will output 
@@ -480,9 +483,9 @@ moving backward and forward in time becomes much easier.
 
 > ## Getting Rid of Staged Changes
 >
-> `git checkout` can be used to restore a previous commit when unstaged changes have
+> `git restore` can be used to restore a previous commit when unstaged changes have
 > been made, but will it also work for changes that have been staged but not committed?
-> Make a change to `mars.txt`, add that change, and use `git checkout` to see if
+> Make a change to `mars.txt`, add that change, and use `git restore` to see if
 > you can remove your change.
 {: .challenge}
 

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -33,11 +33,10 @@ $ git status
 On branch master
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
-
-	a.dat
-	b.dat
-	c.dat
-	results/
+        a.dat
+        b.dat
+        c.dat
+        results/
 
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
@@ -79,8 +78,7 @@ $ git status
 On branch master
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
-
-	.gitignore
+        .gitignore
 
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
@@ -101,7 +99,7 @@ $ git status
 
 ~~~
 On branch master
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 
@@ -115,7 +113,9 @@ $ git add a.dat
 ~~~
 The following paths are ignored by one of your .gitignore files:
 a.dat
-Use -f if you really want to add them.
+hint: Use -f if you really want to add them.
+hint: Turn this message off by running
+hint: "git config advice.addIgnoredFile false"
 ~~~
 {: .output}
 
@@ -132,14 +132,13 @@ $ git status --ignored
 ~~~
 On branch master
 Ignored files:
- (use "git add -f <file>..." to include in what will be committed)
-
+  (use "git add -f <file>..." to include in what will be committed)
         a.dat
         b.dat
         c.dat
         results/
 
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -238,10 +238,11 @@ GitHub, though, this command would download them to our local repository.
 > >
 > > The right-most button lets you view all of the files in the repository at the time of that 
 > > commit. To do this in the shell, we'd need to checkout the repository at that particular time. 
-> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to
+> > We can do this with `git switch --detach ID` 
+> > (or `git checkout ID`, using the older command) where ID is the identifier of the commit we want to
 > > look at. If we do this, we need to remember that we are in
-> > a "detached HEAD" state, and we need to put the repository back 
-> > to the right state afterwards!
+> > a "detached HEAD" state, and we need to put the repository back
+> > to the right state afterwards with `git switch master` (or `git checkout master`)!
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -129,12 +129,12 @@ $ git push origin master
 {: .language-bash}
 
 ~~~
-Enumerating objects: 16, done.
-Counting objects: 100% (16/16), done.
-Delta compression using up to 8 threads.
-Compressing objects: 100% (11/11), done.
-Writing objects: 100% (16/16), 1.45 KiB | 372.00 KiB/s, done.
-Total 16 (delta 2), reused 0 (delta 0)
+Enumerating objects: 12, done.
+Counting objects: 100% (12/12), done.
+Delta compression using up to 8 threads
+Compressing objects: 100% (8/8), done.
+Writing objects: 100% (12/12), 1.09 KiB | 371.00 KiB/s, done.
+Total 12 (delta 2), reused 0 (delta 0), pack-reused 0
 remote: Resolving deltas: 100% (2/2), done.
 To https://github.com/vlad/planets.git
  * [new branch]      master -> master
@@ -209,7 +209,7 @@ $ git pull origin master
 ~~~
 From https://github.com/vlad/planets
  * branch            master     -> FETCH_HEAD
-Already up-to-date.
+Already up to date.
 ~~~
 {: .output}
 
@@ -238,9 +238,10 @@ GitHub, though, this command would download them to our local repository.
 > >
 > > The right-most button lets you view all of the files in the repository at the time of that 
 > > commit. To do this in the shell, we'd need to checkout the repository at that particular time. 
-> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to 
-> > look at. If we do this, we need to remember to put the repository back to the right state 
-> > afterwards!
+> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to
+> > look at. If we do this, we need to remember that we are in
+> > a "detached HEAD" state, and we need to put the repository back 
+> > to the right state afterwards!
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -440,10 +440,10 @@ Conflicts can also be minimized with project management strategies:
 > > On the key line above, Git has conveniently given us commit identifiers
 > > for the two versions of `mars.jpg`. Our version is `HEAD`, and Wolfman's
 > > version is `439dc8c0...`. If we want to use our version, we can use
-> > `git checkout`:
+> > `git restore`:
 > >
 > > ~~~
-> > $ git checkout HEAD mars.jpg
+> > $ git restore mars.jpg   # git checkout HEAD mars.jpg
 > > $ git add mars.jpg
 > > $ git commit -m "Use image of surface instead of sky"
 > > ~~~
@@ -454,11 +454,11 @@ Conflicts can also be minimized with project management strategies:
 > > ~~~
 > > {: .output}
 > >
-> > If instead we want to use Wolfman's version, we can use `git checkout` with
+> > If instead we want to use Wolfman's version, we can use `git restore` with
 > > Wolfman's commit identifier, `439dc8c0`:
 > >
 > > ~~~
-> > $ git checkout 439dc8c0 mars.jpg
+> > $ git restore -s 439dc8c0 mars.jpg   # git checkout 439dc8c0 mars.jpg
 > > $ git add mars.jpg
 > > $ git commit -m "Use image of sky instead of surface"
 > > ~~~
@@ -475,9 +475,9 @@ Conflicts can also be minimized with project management strategies:
 > > image and rename it:
 > >
 > > ~~~
-> > $ git checkout HEAD mars.jpg
+> > $ git restore mars.jpg   # git checkout HEAD mars.jpg
 > > $ git mv mars.jpg mars-surface.jpg
-> > $ git checkout 439dc8c0 mars.jpg
+> > $ git restore -s 439dc8c0 mars.jpg   # git checkout 439dc8c0 mars.jpg
 > > $ mv mars.jpg mars-sky.jpg
 > > ~~~
 > > {: .language-bash}


### PR DESCRIPTION
This PR resolves #691 and changes all references to `git checkout` to either `git restore` (or `git switch`) as appropriate. I believe I got all the references, but a close look at the changes my a maintainer would be great. Since 2.28.0 is the default version in newer versions of Git for Windows and Linux, I think it makes sense to make these changes now. I've included the older syntax in comments in case people are using an older version, too.

I also tried to update the output blocks to reflect the verbiage used by git in more modern versions (I ran all the examples with Git 2.28.0 on Linux).
