### PR TITLE
Update alt-text for RStudio screenshot

### DIFF
--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -102,7 +102,7 @@ The changes can be pushed by selecting "Push Branch" from the Git menu. There
 are also options to pull from the remote repository, and to view the commit
 history:
 
-![](../fig/RStudio_screenshot_history.png)
+![RStudio screenshot showing the git menu dropdown with "History" selected](../fig/RStudio_screenshot_history.png)
 
 > ## Are the Push/Pull Commands Grayed Out?
 >

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -121,7 +121,7 @@ RStudio creates a number of files that it uses to keep track of a project. We
 often don't want to track these, in which case we add them to our `.gitignore`
 file:
 
-![](../fig/RStudio_screenshot_gitignore.png)
+![RStudio screenshot showing .gitignore open in the editor pane with the files .Rproj.user, .Rhistory, .RData, and \*.Rproj added to the end](../fig/RStudio_screenshot_gitignore.png)
 
 > ## Tip: versioning disposable output
 >


### PR DESCRIPTION
Note that the gitignore alt-text is a bit long. It can be shortened if you want to describe the files that are added by default in the text.

This contribution is part of the Core Team accessibility hackathon to add alt-text to images across our lessons. Please feel free to improve upon these suggestions as desired!
