### PR TITLE
Renamed references for "master" branch to "main" branch

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -16,7 +16,7 @@ Once Git is configured,
 we can start using it.
 
 We will continue with the story of Wolfman and Dracula who are investigating if it
-is possible to send a planetary lander to Mars. 
+is possible to send a planetary lander to Mars.
 
 ![motivatingexample](../fig/motivatingexample.png)
 [Werewolf vs dracula](https://www.deviantart.com/b-maze/art/Werewolf-vs-Dracula-124893530)
@@ -80,7 +80,7 @@ $ ls -a
 ~~~
 {: .output}
 
-Git uses this special subdirectory to store all the information about the project, 
+Git uses this special subdirectory to store all the information about the project,
 including all files and sub-directories located within the project's directory.
 If we ever delete the `.git` subdirectory,
 we will lose the project's history.
@@ -93,7 +93,7 @@ $ git status
 ~~~
 {: .language-bash}
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -106,9 +106,9 @@ wording of the output might be slightly different.
 
 > ## Places to Create Git Repositories
 >
-> Along with tracking information about planets (the project we have already created), 
+> Along with tracking information about planets (the project we have already created),
 > Dracula would also like to track information about moons.
-> Despite Wolfman's concerns, Dracula creates a `moons` project inside his `planets` 
+> Despite Wolfman's concerns, Dracula creates a `moons` project inside his `planets`
 > project with the following sequence of commands:
 >
 > ~~~
@@ -122,17 +122,17 @@ wording of the output might be slightly different.
 > ~~~
 > {: .language-bash}
 >
-> Is the `git init` command, run inside the `moons` subdirectory, required for 
+> Is the `git init` command, run inside the `moons` subdirectory, required for
 > tracking files stored in the `moons` subdirectory?
-> 
+>
 > > ## Solution
 > >
-> > No. Dracula does not need to make the `moons` subdirectory a Git repository 
-> > because the `planets` repository will track all files, sub-directories, and 
-> > subdirectory files under the `planets` directory.  Thus, in order to track 
+> > No. Dracula does not need to make the `moons` subdirectory a Git repository
+> > because the `planets` repository will track all files, sub-directories, and
+> > subdirectory files under the `planets` directory.  Thus, in order to track
 > > all information about moons, Dracula only needed to add the `moons` subdirectory
 > > to the `planets` directory.
-> > 
+> >
 > > Additionally, Git repositories can interfere with each other if they are "nested":
 > > the outer repository will try to version-control
 > > the inner repository. Therefore, it's best to create each new Git
@@ -153,7 +153,7 @@ wording of the output might be slightly different.
 {: .challenge}
 > ## Correcting `git init` Mistakes
 > Wolfman explains to Dracula how a nested repository is redundant and may cause confusion
-> down the road. Dracula would like to remove the nested repository. How can Dracula undo 
+> down the road. Dracula would like to remove the nested repository. How can Dracula undo
 > his last `git init` in the `moons` subdirectory?
 >
 > > ## Solution -- USE WITH CAUTION!
@@ -164,7 +164,7 @@ wording of the output might be slightly different.
 > > $ rm filename
 > > ~~~
 > > {: .language-bash}
-> > 
+> >
 > > The file being removed has to be in sync with the branch head with no updates. If there are updates, the file can be removed by force by using the `-f` option. Similarly a directory can be removed from git using `rm -r dirname` or `rm -rf dirname`.
 > >
 > > ### Solution

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -78,7 +78,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -108,7 +108,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -131,7 +131,7 @@ $ git commit -m "Start notes on Mars as a base"
 {: .language-bash}
 
 ~~~
-[master (root-commit) f22b25e] Start notes on Mars as a base
+[main (root-commit) f22b25e] Start notes on Mars as a base
  1 file changed, 1 insertion(+)
  create mode 100644 mars.txt
 ~~~
@@ -161,7 +161,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 nothing to commit, working directory clean
 ~~~
 {: .output}
@@ -227,7 +227,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -290,7 +290,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -312,7 +312,7 @@ $ git commit -m "Add concerns about effects of Mars' moons on Wolfman"
 {: .language-bash}
 
 ~~~
-[master 34961b1] Add concerns about effects of Mars' moons on Wolfman
+[main 34961b1] Add concerns about effects of Mars' moons on Wolfman
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
@@ -439,7 +439,7 @@ $ git commit -m "Discuss concerns about Mars' climate for Mummy"
 {: .language-bash}
 
 ~~~
-[master 005937f] Discuss concerns about Mars' climate for Mummy
+[main 005937f] Discuss concerns about Mars' climate for Mummy
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
@@ -452,7 +452,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 nothing to commit, working directory clean
 ~~~
 {: .output}
@@ -546,7 +546,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > You can also combine the `--oneline` option with others. One useful
 > combination adds `--graph` to display the commit history as a text-based
 > graph and to indicate which commits are associated with the
-> current `HEAD`, the current branch `master`, or
+> current `HEAD`, the current branch `main`, or
 > [other Git references][git-references]:
 >
 > ~~~
@@ -554,7 +554,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > {: .language-bash}
 > ~~~
-> * 005937f (HEAD -> master) Discuss concerns about Mars' climate for Mummy
+> * 005937f (HEAD -> main) Discuss concerns about Mars' climate for Mummy
 > * 34961b1 Add concerns about effects of Mars' moons on Wolfman
 > * f22b25e Start notes on Mars as a base
 > ~~~
@@ -717,7 +717,7 @@ repository (`git commit`):
 > > ~~~
 > > {: .language-bash}
 > > ~~~
-> > [master cc127c2]
+> > [main cc127c2]
 > >  Write plans to start a base on Venus
 > >  2 files changed, 2 insertions(+)
 > >  create mode 100644 venus.txt
@@ -764,7 +764,7 @@ repository (`git commit`):
 > >
 > > ~~~
 > > $ git add me.txt
-> > $ git commit -m "Add biography file" 
+> > $ git commit -m "Add biography file"
 > > ~~~
 > > {: .language-bash}
 > >

--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -60,8 +60,8 @@ index b36abfd..0848c8d 100644
 
 which is the same as what you would get if you leave out `HEAD` (try it).  The
 real goodness in all this is when you can refer to previous commits.  We do
-that by adding `~1` 
-(where "~" is "tilde", pronounced [**til**-d*uh*]) 
+that by adding `~1`
+(where "~" is "tilde", pronounced [**til**-d*uh*])
 to refer to the commit one before `HEAD`.
 
 ~~~
@@ -91,8 +91,8 @@ index df0654a..b36abfd 100644
 ~~~
 {: .output}
 
-We could also use `git show` which shows us what changes we made at an older commit as 
-well as the commit message, rather than the _differences_ between a commit and our 
+We could also use `git show` which shows us what changes we made at an older commit as
+well as the commit message, rather than the _differences_ between a commit and our
 working directory that we see by using `git diff`.
 
 ~~~
@@ -191,7 +191,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -247,7 +247,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -274,9 +274,9 @@ $ git checkout HEAD mars.txt
 > ~~~
 > {: .language-bash}
 >
-> to revert `mars.txt` to its state after the commit `f22b25e`. But be careful! 
+> to revert `mars.txt` to its state after the commit `f22b25e`. But be careful!
 > The command `checkout` has other important functionalities and Git will misunderstand
-> your intentions if you are not accurate with the typing. For example, 
+> your intentions if you are not accurate with the typing. For example,
 > if you forget `mars.txt` in the previous command.
 >
 > ~~~
@@ -301,7 +301,7 @@ $ git checkout HEAD mars.txt
 >
 > The "detached HEAD" is like "look, but don't touch" here,
 > so you shouldn't make any changes in this state.
-> After investigating your repo's past state, reattach your `HEAD` with `git checkout master`.
+> After investigating your repo's past state, reattach your `HEAD` with `git checkout main`.
 {: .callout}
 
 It's important to remember that
@@ -369,20 +369,20 @@ moving backward and forward in time becomes much easier.
 >
 > > ## Solution
 > >
-> > The answer is (5)-Both 2 and 4. 
-> > 
-> > The `checkout` command restores files from the repository, overwriting the files in your working 
-> > directory. Answers 2 and 4 both restore the *latest* version *in the repository* of the file 
-> > `data_cruncher.py`. Answer 2 uses `HEAD` to indicate the *latest*, whereas answer 4 uses the 
-> > unique ID of the last commit, which is what `HEAD` means. 
-> > 
-> > Answer 3 gets the version of `data_cruncher.py` from the commit *before* `HEAD`, which is NOT 
+> > The answer is (5)-Both 2 and 4.
+> >
+> > The `checkout` command restores files from the repository, overwriting the files in your working
+> > directory. Answers 2 and 4 both restore the *latest* version *in the repository* of the file
+> > `data_cruncher.py`. Answer 2 uses `HEAD` to indicate the *latest*, whereas answer 4 uses the
+> > unique ID of the last commit, which is what `HEAD` means.
+> >
+> > Answer 3 gets the version of `data_cruncher.py` from the commit *before* `HEAD`, which is NOT
 > > what we wanted.
-> > 
-> > Answer 1 can be dangerous! Without a filename, `git checkout` will restore **all files** 
-> > in the current directory (and all directories below it) to their state at the commit specified. 
-> > This command will restore `data_cruncher.py` to the latest commit version, but it will also 
-> > restore *any other files that are changed* to that version, erasing any changes you may 
+> >
+> > Answer 1 can be dangerous! Without a filename, `git checkout` will restore **all files**
+> > in the current directory (and all directories below it) to their state at the commit specified.
+> > This command will restore `data_cruncher.py` to the latest commit version, but it will also
+> > restore *any other files that are changed* to that version, erasing any changes you may
 > > have made to those files!
 > > As discussed above, you are left in a *detached* `HEAD` state, and you don't want to be there.
 > {: .solution}
@@ -392,7 +392,7 @@ moving backward and forward in time becomes much easier.
 >
 > Jennifer is collaborating on her Python script with her colleagues and
 > realizes her last commit to the project's repository contained an error and
-> she wants to undo it.  `git revert [erroneous commit ID]` will create a new 
+> she wants to undo it.  `git revert [erroneous commit ID]` will create a new
 > commit that reverses Jennifer's erroneous commit. Therefore `git revert` is
 > different to `git checkout [commit ID]` because `git checkout` returns the
 > files within the local repository to a previous state, whereas `git revert`
@@ -446,21 +446,21 @@ moving backward and forward in time becomes much easier.
 >
 > > ## Solution
 > >
-> > The answer is 2. 
-> > 
-> > The command `git add venus.txt` places the current version of `venus.txt` into the staging area. 
-> > The changes to the file from the second `echo` command are only applied to the working copy, 
+> > The answer is 2.
+> >
+> > The command `git add venus.txt` places the current version of `venus.txt` into the staging area.
+> > The changes to the file from the second `echo` command are only applied to the working copy,
 > > not the version in the staging area.
-> > 
-> > So, when `git commit -m "Comment on Venus as an unsuitable base"` is executed, 
+> >
+> > So, when `git commit -m "Comment on Venus as an unsuitable base"` is executed,
 > > the version of `venus.txt` committed to the repository is the one from the staging area and
 > > has only one line.
 > >  
-> >  At this time, the working copy still has the second line (and 
-> >  `git status` will show that the file is modified). However, `git checkout HEAD venus.txt` 
+> >  At this time, the working copy still has the second line (and
+> >  `git status` will show that the file is modified). However, `git checkout HEAD venus.txt`
 > >  replaces the working copy with the most recently committed version of `venus.txt`.
 > >  
-> >  So, `cat venus.txt` will output 
+> >  So, `cat venus.txt` will output
 > >  ~~~
 > >  Venus is beautiful and full of love.
 > > ~~~
@@ -507,7 +507,7 @@ moving backward and forward in time becomes much easier.
 > Unfortunately some of these commit messages are very ambiguous, e.g., `update files`.
 > How can you search through these files?
 >
-> Both `git diff` and `git log` are very useful and they summarize a different part of the history 
+> Both `git diff` and `git log` are very useful and they summarize a different part of the history
 > for you.
 > Is it possible to combine both? Let's try the following:
 >
@@ -516,7 +516,7 @@ moving backward and forward in time becomes much easier.
 > ~~~
 > {: .language-bash}
 >
-> You should get a long list of output, and you should be able to see both commit messages and 
+> You should get a long list of output, and you should be able to see both commit messages and
 > the difference between each commit.
 >
 > Question: What does the following command do?

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -30,7 +30,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
@@ -76,7 +76,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
@@ -100,7 +100,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 nothing to commit, working directory clean
 ~~~
 {: .output}
@@ -130,7 +130,7 @@ $ git status --ignored
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Ignored files:
  (use "git add -f <file>..." to include in what will be committed)
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -33,9 +33,9 @@ create a new repository called `planets`:
 
 Name your repository "planets" and then click "Create Repository".
 
-Note: Since this repository will be connected to a local repository, it needs to be empty. Leave 
-"Initialize this repository with a README" unchecked, and keep "None" as options for both "Add 
-.gitignore" and "Add a license." See the "GitHub License and README files" exercise below for a full 
+Note: Since this repository will be connected to a local repository, it needs to be empty. Leave
+"Initialize this repository with a README" unchecked, and keep "None" as options for both "Add
+.gitignore" and "Add a license." See the "GitHub License and README files" exercise below for a full
 explanation of why the repository needs to be empty.
 
 ![Creating a Repository on GitHub (Step 2)](../fig/github-create-repo-02.png)
@@ -124,7 +124,7 @@ Once the remote is set up, this command will push the changes from
 our local repository to the repository on GitHub:
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
@@ -137,7 +137,7 @@ Writing objects: 100% (16/16), 1.45 KiB | 372.00 KiB/s, done.
 Total 16 (delta 2), reused 0 (delta 0)
 remote: Resolving deltas: 100% (2/2), done.
 To https://github.com/vlad/planets.git
- * [new branch]      master -> master
+ * [new branch]      main -> main
 ~~~
 {: .output}
 
@@ -196,19 +196,19 @@ Our local and remote repositories are now in this state:
 > option is synonymous with the `--set-upstream-to` option for the `git branch`
 > command, and is used to associate the current branch with a remote branch so
 > that the `git pull` command can be used without any arguments. To do this,
-> simply use `git push -u origin master` once the remote has been set up.
+> simply use `git push -u origin main` once the remote has been set up.
 {: .callout}
 
 We can pull changes from the remote repository to the local one as well:
 
 ~~~
-$ git pull origin master
+$ git pull origin main
 ~~~
 {: .language-bash}
 
 ~~~
 From https://github.com/vlad/planets
- * branch            master     -> FETCH_HEAD
+ * branch            main     -> FETCH_HEAD
 Already up-to-date.
 ~~~
 {: .output}
@@ -226,30 +226,30 @@ GitHub, though, this command would download them to our local repository.
 > How would you get that same information in the shell?
 >
 > > ## Solution
-> > The left-most button (with the picture of a clipboard) copies the full identifier of the commit 
-> > to the clipboard. In the shell, ```git log``` will show you the full commit identifier for each 
+> > The left-most button (with the picture of a clipboard) copies the full identifier of the commit
+> > to the clipboard. In the shell, ```git log``` will show you the full commit identifier for each
 > > commit.
 > >
-> > When you click on the middle button, you'll see all of the changes that were made in that 
-> > particular commit. Green shaded lines indicate additions and red ones removals. In the shell we 
-> > can do the same thing with ```git diff```. In particular, ```git diff ID1..ID2``` where ID1 and 
-> > ID2 are commit identifiers (e.g. ```git diff a3bf1e5..041e637```) will show the differences 
+> > When you click on the middle button, you'll see all of the changes that were made in that
+> > particular commit. Green shaded lines indicate additions and red ones removals. In the shell we
+> > can do the same thing with ```git diff```. In particular, ```git diff ID1..ID2``` where ID1 and
+> > ID2 are commit identifiers (e.g. ```git diff a3bf1e5..041e637```) will show the differences
 > > between those two commits.
 > >
-> > The right-most button lets you view all of the files in the repository at the time of that 
-> > commit. To do this in the shell, we'd need to checkout the repository at that particular time. 
-> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to 
-> > look at. If we do this, we need to remember to put the repository back to the right state 
+> > The right-most button lets you view all of the files in the repository at the time of that
+> > commit. To do this in the shell, we'd need to checkout the repository at that particular time.
+> > We can do this with ```git checkout ID``` where ID is the identifier of the commit we want to
+> > look at. If we do this, we need to remember to put the repository back to the right state
 > > afterwards!
 > {: .solution}
 {: .challenge}
 
 > ## Uploading files directly in GitHub browser
 >
-> Github also allows you to skip the command line and upload files directly to 
-> your repository without having to leave the browser. There are two options. 
+> Github also allows you to skip the command line and upload files directly to
+> your repository without having to leave the browser. There are two options.
 > First you can click the "Upload files" button in the toolbar at the top of the
-> file tree. Or, you can drag and drop files from your desktop onto the file 
+> file tree. Or, you can drag and drop files from your desktop onto the file
 > tree. You can read more about this [on this GitHub page](https://help.github.com/articles/adding-a-file-to-a-repository/)
 {: .callout}
 
@@ -262,8 +262,8 @@ GitHub, though, this command would download them to our local repository.
 > record times, and why?
 >
 > > ## Solution
-> > GitHub displays timestamps in a human readable relative format (i.e. "22 hours ago" or "three 
-> > weeks ago"). However, if you hover over the timestamp, you can see the exact time at which the 
+> > GitHub displays timestamps in a human readable relative format (i.e. "22 hours ago" or "three
+> > weeks ago"). However, if you hover over the timestamp, you can see the exact time at which the
 > > last change to the file occurred.
 > {: .solution}
 {: .challenge}
@@ -274,25 +274,25 @@ GitHub, though, this command would download them to our local repository.
 > How is "git push" different from "git commit"?
 >
 > > ## Solution
-> > When we push changes, we're interacting with a remote repository to update it with the changes 
-> > we've made locally (often this corresponds to sharing the changes we've made with others). 
+> > When we push changes, we're interacting with a remote repository to update it with the changes
+> > we've made locally (often this corresponds to sharing the changes we've made with others).
 > > Commit only updates your local repository.
 > {: .solution}
 {: .challenge}
 
 > ## GitHub License and README files
 >
-> In this section we learned about creating a remote repository on GitHub, but when you initialized 
-> your GitHub repo, you didn't add a README.md or a license file. If you had, what do you think 
+> In this section we learned about creating a remote repository on GitHub, but when you initialized
+> your GitHub repo, you didn't add a README.md or a license file. If you had, what do you think
 > would have happened when you tried to link your local and remote repositories?
 >
 > > ## Solution
-> > In this case, we'd see a merge conflict due to unrelated histories. When GitHub creates a 
-> > README.md file, it performs a commit in the remote repository. When you try to pull the remote 
-> > repository to your local repository, Git detects that they have histories that do not share a 
+> > In this case, we'd see a merge conflict due to unrelated histories. When GitHub creates a
+> > README.md file, it performs a commit in the remote repository. When you try to pull the remote
+> > repository to your local repository, Git detects that they have histories that do not share a
 > > common origin and refuses to merge.
 > > ~~~
-> > $ git pull origin master
+> > $ git pull origin main
 > > ~~~
 > > {: .language-bash}
 > >
@@ -303,23 +303,23 @@ GitHub, though, this command would download them to our local repository.
 > > remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
 > > Unpacking objects: 100% (3/3), done.
 > > From https://github.com/vlad/planets
-> >  * branch            master     -> FETCH_HEAD
-> >  * [new branch]      master     -> origin/master
+> >  * branch            main     -> FETCH_HEAD
+> >  * [new branch]      main     -> origin/main
 > > fatal: refusing to merge unrelated histories
 > > ~~~
 > > {: .output}
 > >
-> > You can force git to merge the two repositories with the option `--allow-unrelated-histories`. 
-> > Be careful when you use this option and carefully examine the contents of local and remote 
+> > You can force git to merge the two repositories with the option `--allow-unrelated-histories`.
+> > Be careful when you use this option and carefully examine the contents of local and remote
 > > repositories before merging.
 > > ~~~
-> > $ git pull --allow-unrelated-histories origin master
+> > $ git pull --allow-unrelated-histories origin main
 > > ~~~
 > > {: .language-bash}
 > >
 > > ~~~
 > > From https://github.com/vlad/planets
-> >  * branch            master     -> FETCH_HEAD
+> >  * branch            main     -> FETCH_HEAD
 > > Merge made by the 'recursive' strategy.
 > > README.md | 1 +
 > > 1 file changed, 1 insertion(+)

--- a/_episodes/08-collab.md
+++ b/_episodes/08-collab.md
@@ -78,7 +78,7 @@ $ git commit -m "Add notes about Pluto"
 Then push the change to the *Owner's repository* on GitHub:
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
@@ -90,7 +90,7 @@ Compressing objects: 100% (2/2), done.
 Writing objects: 100% (3/3), 306 bytes, done.
 Total 3 (delta 0), reused 0 (delta 0)
 To https://github.com/vlad/planets.git
-   9272da5..29aba7c  master -> master
+   9272da5..29aba7c  main -> main
 ~~~
 {: .output}
 
@@ -102,12 +102,12 @@ sensible choice earlier when we were setting up remotes by hand.)
 >
 > In this episode and the previous one, our local repository has had
 > a single "remote", called `origin`. A remote is a copy of the repository
-> that is hosted somewhere else, that we can push to and pull from, and 
-> there's no reason that you have to work with only one. For example, 
+> that is hosted somewhere else, that we can push to and pull from, and
+> there's no reason that you have to work with only one. For example,
 > on some large projects you might have your own copy in your own GitHub
 > account (you'd probably call this `origin`) and also the main "upstream"
 > project repository (let's call this `upstream` for the sake of examples).
-> You would pull from `upstream` from time to 
+> You would pull from `upstream` from time to
 > time to get the latest updates that other people have committed.
 >
 > Remember that the name you give to a remote only exists locally. It's
@@ -120,13 +120,13 @@ sensible choice earlier when we were setting up remotes by hand.)
 > * `git remote -v` lists all the remotes that are configured (we already used
 > this in the last episode)
 > * `git remote add [name] [url]` is used to add a new remote
-> * `git remote remove [name]` removes a remote. Note that it doesn't affect the 
+> * `git remote remove [name]` removes a remote. Note that it doesn't affect the
 > remote repository at all - it just removes the link to it from the local repo.
-> * `git remote set-url [name] [newurl]` changes the URL that is associated 
+> * `git remote set-url [name] [newurl]` changes the URL that is associated
 > with the remote. This is useful if it has moved, e.g. to a different GitHub
 > account, or from GitHub to a different hosting service. Or, if we made a typo when
 > adding it!
-> * `git remote rename [oldname] [newname]` changes the local alias by which a remote 
+> * `git remote rename [oldname] [newname]` changes the local alias by which a remote
 > is known - its name. For example, one could use this to change `upstream` to `fred`.
 {: .callout}
 
@@ -137,7 +137,7 @@ Collaborator.
 To download the Collaborator's changes from GitHub, the Owner now enters:
 
 ~~~
-$ git pull origin master
+$ git pull origin main
 ~~~
 {: .language-bash}
 
@@ -148,8 +148,8 @@ remote: Compressing objects: 100% (2/2), done.
 remote: Total 3 (delta 0), reused 3 (delta 0), pack-reused 0
 Unpacking objects: 100% (3/3), done.
 From https://github.com/vlad/planets
- * branch            master     -> FETCH_HEAD
-   9272da5..29aba7c  master     -> origin/master
+ * branch            main     -> FETCH_HEAD
+   9272da5..29aba7c  main     -> origin/main
 Updating 9272da5..29aba7c
 Fast-forward
  pluto.txt | 1 +
@@ -167,10 +167,10 @@ GitHub) are back in sync.
 > repository you are collaborating on, so you should `git pull` before making
 > our changes. The basic collaborative workflow would be:
 >
-> * update your local repo with `git pull origin master`,
+> * update your local repo with `git pull origin main`,
 > * make your changes and stage them with `git add`,
 > * commit your changes with `git commit -m`, and
-> * upload the changes to GitHub with `git push origin master`
+> * upload the changes to GitHub with `git push origin main`
 >
 > It is better to make many commits with smaller changes rather than
 > of one commit with massive changes: small commits are easier to
@@ -189,12 +189,12 @@ GitHub) are back in sync.
 > command line? And on GitHub?
 >
 > > ## Solution
-> > On the command line, the Collaborator can use ```git fetch origin master```
+> > On the command line, the Collaborator can use ```git fetch origin main```
 > > to get the remote changes into the local repository, but without merging
-> > them. Then by running ```git diff master origin/master``` the Collaborator
+> > them. Then by running ```git diff main origin/main``` the Collaborator
 > > will see the changes output in the terminal.
 > >
-> > On GitHub, the Collaborator can go to the repository and click on 
+> > On GitHub, the Collaborator can go to the repository and click on
 > > "commits" to view the most recent commits pushed to the repository.
 > {: .solution}
 {: .challenge}

--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -60,13 +60,13 @@ $ git commit -m "Add a line in our home copy"
 {: .language-bash}
 
 ~~~
-[master 5ae9631] Add a line in our home copy
+[main 5ae9631] Add a line in our home copy
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
@@ -79,7 +79,7 @@ Writing objects: 100% (3/3), 331 bytes | 331.00 KiB/s, done.
 Total 3 (delta 2), reused 0 (delta 0)
 remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
 To https://github.com/vlad/planets.git
-   29aba7c..dabb4c8  master -> master
+   29aba7c..dabb4c8  main -> main
 ~~~
 {: .output}
 
@@ -110,7 +110,7 @@ $ git commit -m "Add a line in my copy"
 {: .language-bash}
 
 ~~~
-[master 07ebc69] Add a line in my copy
+[main 07ebc69] Add a line in my copy
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
@@ -118,13 +118,13 @@ $ git commit -m "Add a line in my copy"
 but Git won't let us push it to GitHub:
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
 ~~~
 To https://github.com/vlad/planets.git
- ! [rejected]        master -> master (fetch first)
+ ! [rejected]        main -> main (fetch first)
 error: failed to push some refs to 'https://github.com/vlad/planets.git'
 hint: Updates were rejected because the remote contains work that you do
 hint: not have locally. This is usually caused by another repository pushing
@@ -143,7 +143,7 @@ What we have to do is pull the changes from GitHub,
 Let's start by pulling:
 
 ~~~
-$ git pull origin master
+$ git pull origin main
 ~~~
 {: .language-bash}
 
@@ -154,8 +154,8 @@ remote: Compressing objects: 100% (1/1), done.
 remote: Total 3 (delta 2), reused 3 (delta 2), pack-reused 0
 Unpacking objects: 100% (3/3), done.
 From https://github.com/vlad/planets
- * branch            master     -> FETCH_HEAD
-    29aba7c..dabb4c8  master     -> origin/master
+ * branch            main     -> FETCH_HEAD
+    29aba7c..dabb4c8  main     -> origin/main
 Auto-merging mars.txt
 CONFLICT (content): Merge conflict in mars.txt
 Automatic merge failed; fix conflicts and then commit the result.
@@ -164,7 +164,7 @@ Automatic merge failed; fix conflicts and then commit the result.
 
 The `git pull` command updates the local repository to include those
 changes already included in the remote repository.
-After the changes from remote branch have been fetched, Git detects that changes made to the local copy 
+After the changes from remote branch have been fetched, Git detects that changes made to the local copy
 overlap with those made to the remote repository, and therefore refuses to merge the two versions to
 stop us from trampling on our previous work. The conflict is marked in
 in the affected file:
@@ -223,7 +223,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 All conflicts fixed but you are still merging.
   (use "git commit" to conclude merge)
 
@@ -240,14 +240,14 @@ $ git commit -m "Merge changes from GitHub"
 {: .language-bash}
 
 ~~~
-[master 2abf2b1] Merge changes from GitHub
+[main 2abf2b1] Merge changes from GitHub
 ~~~
 {: .output}
 
 Now we can push our changes to GitHub:
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
@@ -260,7 +260,7 @@ Writing objects: 100% (6/6), 645 bytes | 645.00 KiB/s, done.
 Total 6 (delta 4), reused 0 (delta 0)
 remote: Resolving deltas: 100% (4/4), completed with 2 local objects.
 To https://github.com/vlad/planets.git
-   dabb4c8..2abf2b1  master -> master
+   dabb4c8..2abf2b1  main -> main
 ~~~
 {: .output}
 
@@ -269,7 +269,7 @@ so we don't have to fix things by hand again
 when the collaborator who made the first change pulls again:
 
 ~~~
-$ git pull origin master
+$ git pull origin main
 ~~~
 {: .language-bash}
 
@@ -280,8 +280,8 @@ remote: Compressing objects: 100% (2/2), done.
 remote: Total 6 (delta 4), reused 6 (delta 4), pack-reused 0
 Unpacking objects: 100% (6/6), done.
 From https://github.com/vlad/planets
- * branch            master     -> FETCH_HEAD
-    dabb4c8..2abf2b1  master     -> origin/master
+ * branch            main     -> FETCH_HEAD
+    dabb4c8..2abf2b1  main     -> origin/main
 Updating dabb4c8..2abf2b1
 Fast-forward
  mars.txt | 2 +-
@@ -312,7 +312,7 @@ correctly. If you find yourself resolving a lot of conflicts in a project,
 consider these technical approaches to reducing them:
 
 - Pull from upstream more frequently, especially before starting new work
-- Use topic branches to segregate work, merging to master when complete
+- Use topic branches to segregate work, merging to main when complete
 - Make smaller more atomic commits
 - Where logically appropriate, break large files into smaller ones so that it is
   less likely that two authors will alter the same file simultaneously
@@ -373,7 +373,7 @@ Conflicts can also be minimized with project management strategies:
 > > {: .language-bash}
 > >
 > > ~~~
-> > [master 8e4115c] Add picture of Martian surface
+> > [main 8e4115c] Add picture of Martian surface
 > >  1 file changed, 0 insertions(+), 0 deletions(-)
 > >  create mode 100644 mars.jpg
 > > ~~~
@@ -384,13 +384,13 @@ Conflicts can also be minimized with project management strategies:
 > > When Dracula tries to push, he gets a familiar message:
 > >
 > > ~~~
-> > $ git push origin master
+> > $ git push origin main
 > > ~~~
 > > {: .language-bash}
 > >
 > > ~~~
 > > To https://github.com/vlad/planets.git
-> >  ! [rejected]        master -> master (fetch first)
+> >  ! [rejected]        main -> main (fetch first)
 > > error: failed to push some refs to 'https://github.com/vlad/planets.git'
 > > hint: Updates were rejected because the remote contains work that you do
 > > hint: not have locally. This is usually caused by another repository pushing
@@ -403,7 +403,7 @@ Conflicts can also be minimized with project management strategies:
 > > We've learned that we must pull first and resolve any conflicts:
 > >
 > > ~~~
-> > $ git pull origin master
+> > $ git pull origin main
 > > ~~~
 > > {: .language-bash}
 > >
@@ -411,14 +411,14 @@ Conflicts can also be minimized with project management strategies:
 > > a message like this:
 > >
 > > ~~~
-> > $ git pull origin master
+> > $ git pull origin main
 > > remote: Counting objects: 3, done.
 > > remote: Compressing objects: 100% (3/3), done.
 > > remote: Total 3 (delta 0), reused 0 (delta 0)
 > > Unpacking objects: 100% (3/3), done.
 > > From https://github.com/vlad/planets.git
-> >  * branch            master     -> FETCH_HEAD
-> >    6a67967..439dc8c  master     -> origin/master
+> >  * branch            main     -> FETCH_HEAD
+> >    6a67967..439dc8c  main     -> origin/main
 > > warning: Cannot merge binary files: mars.jpg (HEAD vs. 439dc8c08869c342438f6dc4a2b615b05b93c76e)
 > > Auto-merging mars.jpg
 > > CONFLICT (add/add): Merge conflict in mars.jpg
@@ -450,7 +450,7 @@ Conflicts can also be minimized with project management strategies:
 > > {: .language-bash}
 > >
 > > ~~~
-> > [master 21032c3] Use image of surface instead of sky
+> > [main 21032c3] Use image of surface instead of sky
 > > ~~~
 > > {: .output}
 > >
@@ -465,7 +465,7 @@ Conflicts can also be minimized with project management strategies:
 > > {: .language-bash}
 > >
 > > ~~~
-> > [master da21b34] Use image of sky instead of surface
+> > [main da21b34] Use image of sky instead of surface
 > > ~~~
 > > {: .output}
 > >
@@ -493,7 +493,7 @@ Conflicts can also be minimized with project management strategies:
 > > {: .language-bash}
 > >
 > > ~~~
-> > [master 94ae08c] Use two images: surface and sky
+> > [main 94ae08c] Use two images: surface and sky
 > >  2 files changed, 0 insertions(+), 0 deletions(-)
 > >  create mode 100644 mars-sky.jpg
 > >  rename mars.jpg => mars-surface.jpg (100%)
@@ -537,11 +537,11 @@ Conflicts can also be minimized with project management strategies:
 > >
 > > |order|action . . . . . . |command . . . . . . . . . . . . . . . . . . . |
 > > |-----|-------------------|----------------------------------------------|
-> > |1    | Update local      | `git pull origin master`                     |
+> > |1    | Update local      | `git pull origin main`                     |
 > > |2    | Make changes      | `echo 100 >> numbers.txt`                    |
 > > |3    | Stage changes     | `git add numbers.txt`                        |
 > > |4    | Commit changes    | `git commit -m "Add 100 to numbers.txt"`     |
-> > |5    | Update remote     | `git push origin master`                     |
+> > |5    | Update remote     | `git push origin main`                     |
 > > |6    | Celebrate!        | `AFK`                                        |
 > >
 > {: .solution}

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -46,17 +46,17 @@ our computer, we choose the option "Existing Directory":
 > - `which git` (Mac, Linux)
 > - `where git` (Windows)
 >
-> If there is no version of Git on your computer, 
-please follow the 
-[Git installation 
+> If there is no version of Git on your computer,
+please follow the
+[Git installation
 instructions](https://swcarpentry.github.io/git-novice/setup.html)
-> in the setup of this lesson to install Git now. Next open your shell or command prompt 
+> in the setup of this lesson to install Git now. Next open your shell or command prompt
 > and type `which git` (Mac, Linux), or `where git` (Windows).
 > Copy the path to the git executable.
 >
 > e.g. On one Windows computer which had GitHub Desktop installed on it, the path was:
 > `C:/Users/UserName/AppData/Local/GitHubDesktop/app-1.1.1/resources/app/git/cmd/git.exe`
-> 
+>
 > NOTE: The path on your computer will be somewhat different.
 > ### Tell RStudio where to find GitHub
 > In RStudio, go to the `Tools` menu > `Global Options` > `Git/SVN` and then
@@ -109,7 +109,7 @@ history:
 > Grayed out Push/Pull commands generally mean that RStudio doesn't know the
 > location of your remote repository (e.g. on GitHub). To fix this, open a
 > terminal to the repository and enter the command: `git push -u origin
-> master`. Then restart RStudio.
+> main`. Then restart RStudio.
 {: .callout}
 
 If we click on "History", we can see a graphical version of what `git log`
@@ -142,7 +142,7 @@ file:
 > > ```
 > > dir.create("./graphs")
 > > ```
-> > Then open up the `.gitignore` file from the righ-hand panel of Rstudio and add 
+> > Then open up the `.gitignore` file from the righ-hand panel of Rstudio and add
 > > `graphs/` to the list of files to ignore.
 > > {: . shell}
 > {: .solution}


### PR DESCRIPTION
This pull request changes all references to the "master" branch to the "main" branch instead.

Use of a "master" branch is generally discouraged as culturally insensitive and the most recent versions of git default to a "main" branch instead. Although some Carpentries users may have older versions of git that still default to a "master" branch, I think it would be best for the language on the website to reflect the more culturally sensitive (and most up-to-date) use.