### PR TITLE
Added keypoint to the 11-licensing.md about including a LICENSE file

### DIFF
--- a/_episodes/11-licensing.md
+++ b/_episodes/11-licensing.md
@@ -9,6 +9,7 @@ objectives:
 - "Choose a proper license."
 - "Explain differences in licensing and social expectations."
 keypoints:
+- "Add a LICENSE file to a repository to explain how your work can be used by others."
 - "People who incorporate General Public License (GPL'd) software into their own software must make their software also open under the GPL license; most other open licenses do not require this."
 - "The Creative Commons family of licenses allow people to mix and match requirements and restrictions on attribution, creation of derivative works, further sharing, and commercialization."
 - "People who are not lawyers should not try to write licenses from scratch."

--- a/_episodes/11-licensing.md
+++ b/_episodes/11-licensing.md
@@ -9,7 +9,7 @@ objectives:
 - "Choose a proper license."
 - "Explain differences in licensing and social expectations."
 keypoints:
-- "The LICENSE or LICENSE.txt file is often used in a repository to indicate how the contents of the repo may be used by others."
+- "The `LICENSE`, `LICENSE.md`, or `LICENSE.txt` file is often used in a repository to indicate how the contents of the repo may be used by others."
 - "People who incorporate General Public License (GPL'd) software into their own software must make their software also open under the GPL license; most other open licenses do not require this."
 - "The Creative Commons family of licenses allow people to mix and match requirements and restrictions on attribution, creation of derivative works, further sharing, and commercialization."
 - "People who are not lawyers should not try to write licenses from scratch."

--- a/_episodes/11-licensing.md
+++ b/_episodes/11-licensing.md
@@ -9,7 +9,7 @@ objectives:
 - "Choose a proper license."
 - "Explain differences in licensing and social expectations."
 keypoints:
-- "Add a LICENSE file to a repository to explain how your work can be used by others."
+- "The LICENSE or LICENSE.txt file is often used in a repository to indicate how the contents of the repo may be used by others."
 - "People who incorporate General Public License (GPL'd) software into their own software must make their software also open under the GPL license; most other open licenses do not require this."
 - "The Creative Commons family of licenses allow people to mix and match requirements and restrictions on attribution, creation of derivative works, further sharing, and commercialization."
 - "People who are not lawyers should not try to write licenses from scratch."


### PR DESCRIPTION
Added a keypoint to the 11-licensing.md episode about the importance of a LICENSE file in a repository to close #791 .While this topic is covered in the lesson, this change is just so that this point will appear on the Quick Reference page (reference.html automatically updates and displays all the keypoints).
