### PR TITLE
Update 05-history.md

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -191,7 +191,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)


### PR DESCRIPTION
I am proposing changing 'master' to 'main' in keeping with current GitHub practice for the root branch for a git repository. This is part of my certification for becoming a Software Carpentries instructor.