### PR TITLE
Update 05-history.md

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -191,7 +191,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -247,7 +247,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -301,7 +301,7 @@ $ git checkout HEAD mars.txt
 >
 > The "detached HEAD" is like "look, but don't touch" here,
 > so you shouldn't make any changes in this state.
-> After investigating your repo's past state, reattach your `HEAD` with `git checkout master`.
+> After investigating your repo's past state, reattach your `HEAD` with `git checkout main`.
 {: .callout}
 
 It's important to remember that


### PR DESCRIPTION
I am proposing changing 'master' to 'main' in keeping with current GitHub practice for the root branch for a git repository. This is part of my certification for becoming a Software Carpentries instructor.