### PR TITLE
Update 14-supplemental-rstudio.md

### DIFF
--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -109,7 +109,7 @@ history:
 > Grayed out Push/Pull commands generally mean that RStudio doesn't know the
 > location of your remote repository (e.g. on GitHub). To fix this, open a
 > terminal to the repository and enter the command: `git push -u origin
-> master`. Then restart RStudio.
+> main`. Then restart RStudio.
 {: .callout}
 
 If we click on "History", we can see a graphical version of what `git log`


### PR DESCRIPTION
I am proposing changing 'master' to 'main' one time in this document in keeping with current GitHub practice for the root branch for a git repository. Also, two of the figures will need to be done again to change references to 'master' to 'main': RStudio_screenshot_review.png and RStudio_screenshot_viewhistory.png. This is part of my certification for becoming a Software Carpentries instructor.