### PR TITLE
Adding YAML header to AIO generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/aio.md
+++ b/aio.md
@@ -1,9 +1,10 @@
 ---
+permalink: /aio/index.html
 ---
 
 {% comment %}
 As a maintainer, you don't need to edit this file.
-If you notice that something doesn't work, please 
+If you notice that something doesn't work, please
 open an issue: https://github.com/carpentries/styles/issues/new
 {% endcomment %}
 


### PR DESCRIPTION
Added Gemfile to allow for local testing and added missing `permalink` yaml value to aio.md to correct errors in image links in generated AIO page. 

Tested on local system and in Github pages

ref. Issue: https://github.com/swcarpentry/git-novice/issues/801
