### PR TITLE
Update to main branch after init

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -146,7 +146,8 @@ same commands to choose another editor or update your email address.
 > when you create a new repository with `git init` (as explained in the next Episode). This term evokes 
 > the racist practice of human slavery and the software development community has moved to adopt 
 > more inclusive language. Notably, new repositories created through GitHub use `main` as the default
-> branch name.
+> branch name.  
+> Read more about how to implement this change in [GitHub's renaming repository](https://github.com/github/renaming).
 >
 > With Git versions 2.28 and higher, you can set a different name for the initial branch. To set main as 
 > the default branch name do:

--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -116,6 +116,14 @@ $ git config --global init.defaultBranch main
 
 > ## Default Git branch naming
 >
+> Source file changes are associated with a "branch." 
+> For new learners in this lesson, it's enough to know that branches exist, and this lesson uses one branch.  
+> By default, Git will create a branch called `master` 
+> when you create a new repository with `git init` (as explained in the next Episode). This term evokes 
+> the racist practice of human slavery and the 
+> [software development community](https://github.com/github/renaming)  has moved to adopt 
+> more inclusive language. 
+> 
 > In 2020, most Git code hosting services transitioned to using `main` as the default 
 > branch. As an example, any new repository that is opened in GitHub and GitLab default 
 > to `main`.  However, Git has not yet made the same change.  As a result, local repositories 
@@ -139,23 +147,6 @@ $ git config --list
 
 You can change your configuration as many times as you want: use the
 same commands to choose another editor or update your email address.
-
-> ## Default Branch Name
-> 
-> Source file changes are associated with a "branch." By default, Git will create a branch called `master` 
-> when you create a new repository with `git init` (as explained in the next Episode). This term evokes 
-> the racist practice of human slavery and the software development community has moved to adopt 
-> more inclusive language. Notably, new repositories created through GitHub use `main` as the default
-> branch name.  
-> Read more about how to implement this change in [GitHub's renaming repository](https://github.com/github/renaming).
->
-> With Git versions 2.28 and higher, you can set a different name for the initial branch. To set main as 
-> the default branch name do:
->
-> ~~~
-> $ git config --global init.defaultBranch main
-> ~~~
-> {: .language-bash}
 
 > ## Proxy
 >

--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -118,6 +118,22 @@ $ git config --list
 You can change your configuration as many times as you want: use the
 same commands to choose another editor or update your email address.
 
+> ## Default Branch Name
+> 
+> Source file changes are associated with a "branch." By default, Git will create a branch called `master` 
+> when you create a new repository with `git init` (as explained in the next Episode). This term evokes 
+> the racist practice of human slavery and the software development community has moved to adopt 
+> more inclusive language. Notably, new repositories created through GitHub use `main` as the default
+> branch name.
+>
+> With Git versions 2.28 and higher, you can set a different name for the initial branch. To set main as 
+> the default branch name do:
+>
+> ~~~
+> $ git config --global init.defaultBranch main
+> ~~~
+> {: .language-bash}
+
 > ## Proxy
 >
 > In some networks you need to use a

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -85,6 +85,21 @@ including all files and sub-directories located within the project's directory.
 If we ever delete the `.git` subdirectory,
 we will lose the project's history.
 
+Next, we will change the default branch to be called `main`.
+This might be the default branch depending on your settings and version
+of git.
+See the [setup episode](02-setup.md) for more information on this change.
+
+~~~
+git checkout -b main
+~~~
+{: .language-bash}
+~~~
+Switched to a new branch 'main'
+~~~
+{: .output}
+
+
 We can check that everything is set up correctly
 by asking Git to tell us the status of our project:
 


### PR DESCRIPTION
Based on the discussion in issue #761.  Created a PR that switches to the main branch after initializing.  Text edits welcome!

Also added in setup episode suggestion from @srerickson.  @srerickson let me know if you'd prefer I revert that commit so you can get credit in the history.

This does not address all the subsequent times that the branch name appears in the status command.  Looks like there are already a few PRs on that topic #788 and #793