### PR TITLE
Add notepad.exe as git text editor

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -87,6 +87,7 @@ Dracula also has to set his favorite text editor, following this table:
 | Sublime Text (Mac) | `$ git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl -n -w"` |
 | Sublime Text (Win, 32-bit install) | `$ git config --global core.editor "'c:/program files (x86)/sublime text 3/sublime_text.exe' -w"` |
 | Sublime Text (Win, 64-bit install) | `$ git config --global core.editor "'c:/program files/sublime text 3/sublime_text.exe' -w"` |
+| Notepad (Win) | `$ git config --global core.editor "notepad"` |
 | Notepad++ (Win, 32-bit install)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
 | Notepad++ (Win, 64-bit install)    | `$ git config --global core.editor "'c:/program files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
 | Kate (Linux)       | `$ git config --global core.editor "kate"`       |


### PR DESCRIPTION
For windows users who prefer to avoid installing a third-party text editor, notepad.exe is a viable option for git's default editor. Added a row to the editors table for setting notepad.exe as the `core.editor`.