### PR TITLE
DOC: Improve explanation about getting `git` help

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -153,7 +153,7 @@ same commands to choose another editor or update your email address.
 >
 > While viewing the manual, remember the `:` is a prompt waiting for commands and you can press <kbd>Q</kbd> to exit the manual.
 >
-> More generally, you can get the list of available `git` commands and further resources of the `git` manual typing:
+> More generally, you can get the list of available `git` commands and further resources of the Git manual typing:
 >
 > ~~~
 > $ git help

--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -141,7 +141,9 @@ same commands to choose another editor or update your email address.
 
 > ## Git Help and Manual
 >
-> Always remember that if you forget a `git` command, you can access the list of commands by using `-h` and access the Git manual by using `--help` :
+> Always remember that if you forget the subcommands or options of a `git` command, you can access the
+> relevant list of options typing `git <command> -h` or access the corresponding Git manual by typing
+> `git <command> --help`, e.g.:
 >
 > ~~~
 > $ git config -h
@@ -150,6 +152,13 @@ same commands to choose another editor or update your email address.
 > {: .language-bash}
 >
 > While viewing the manual, remember the `:` is a prompt waiting for commands and you can press <kbd>Q</kbd> to exit the manual.
+>
+> More generally, you can get the list of available `git` commands and further resources of the `git` manual typing:
+>
+> ~~~
+> $ git help
+> ~~~
+> {: .language-bash}
 >
 {: .callout}
 


### PR DESCRIPTION
Improve explanation about getting `git` help:
- Re-word the existing paragraph to make it clear that it refers to the case
  where the `git` command is known, but its options are unknown.
- Add a paragraph on how to get general help on available `git` commands.

Fixes #438.