### PR TITLE
ENH: Show default branch name command

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -105,8 +105,9 @@ your changes, press <kbd>Esc</kbd> then type `:q!` and hit <kbd>Return</kbd>.
 > If you want to save your changes and quit, press <kbd>Esc</kbd> then type `:wq` and hit <kbd>Return</kbd>.
 {: .callout}
 
-Recent versions of Git (since 2.28) allow to configure the name of the branch created when you
-initialize any new repository. Dracula decides to use that feature to set it to `main`:
+Git (2.28+) allows configuration of the name of the branch created when you
+initialize any new repository.  Dracula decides to use that feature to set it to `main` so 
+it matches the cloud service he will eventually use. 
 
 ~~~
 $ git config --global init.defaultBranch main
@@ -115,14 +116,14 @@ $ git config --global init.defaultBranch main
 
 > ## Default Git branch naming
 >
-> Until recently, Git and the code hosting services mentioned in this episode have used a
-> a different name for the default branch, but have transitioned to using `main`. As an example,
-> any new repository that is opened in GitHub and GitLab default to `main`.
->
-> Note that if that value is unset in your local Git configuration, the `init.defaultBranch` value
-> defaults to `master`.
->
-> Further information about the change can be found in the [GitHub blog entry about Git 2.28](https://lore.kernel.org/git/xmqq5za8hpir.fsf@gitster.c.googlers.com/).
+> In 2020, most git code hosting services transitioned to using `main` as the default 
+> branch. As an example, any new repository that is opened in GitHub and GitLab default 
+> to `main`.  However, git has not yet made the same change.  As a result, local repositories 
+> must be manually configured have the same main branch name as most cloud services.  
+> 
+> For versions of git prior to 2.28, the change can be made on an individual repository level.  The 
+> command for this is in the next episode.  Note that if this value is unset in your local Git 
+> configuration, the `init.defaultBranch` value defaults to `master`.
 >
 {: .callout}
 

--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -116,12 +116,12 @@ $ git config --global init.defaultBranch main
 
 > ## Default Git branch naming
 >
-> In 2020, most git code hosting services transitioned to using `main` as the default 
+> In 2020, most Git code hosting services transitioned to using `main` as the default 
 > branch. As an example, any new repository that is opened in GitHub and GitLab default 
-> to `main`.  However, git has not yet made the same change.  As a result, local repositories 
+> to `main`.  However, Git has not yet made the same change.  As a result, local repositories 
 > must be manually configured have the same main branch name as most cloud services.  
 > 
-> For versions of git prior to 2.28, the change can be made on an individual repository level.  The 
+> For versions of Git prior to 2.28, the change can be made on an individual repository level.  The 
 > command for this is in the next episode.  Note that if this value is unset in your local Git 
 > configuration, the `init.defaultBranch` value defaults to `master`.
 >

--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -105,7 +105,28 @@ your changes, press <kbd>Esc</kbd> then type `:q!` and hit <kbd>Return</kbd>.
 > If you want to save your changes and quit, press <kbd>Esc</kbd> then type `:wq` and hit <kbd>Return</kbd>.
 {: .callout}
 
-The four commands we just ran above only need to be run once: the flag `--global` tells Git
+Recent versions of Git (since 2.28) allow to configure the name of the branch created when you
+initialize any new repository. Dracula decides to use that feature to set it to `main`:
+
+~~~
+$ git config --global init.defaultBranch main
+~~~
+{: .language-bash}
+
+> ## Default Git branch naming
+>
+> Until recently, Git and the code hosting services mentioned in this episode have used a
+> a different name for the default branch, but have transitioned to using `main`. As an example,
+> any new repository that is opened in GitHub and GitLab default to `main`.
+>
+> Note that if that value is unset in your local Git configuration, the `init.defaultBranch` value
+> defaults to `master`.
+>
+> Further information about the change can be found in the [GitHub blog entry about Git 2.28](https://lore.kernel.org/git/xmqq5za8hpir.fsf@gitster.c.googlers.com/).
+>
+{: .callout}
+
+The five commands we just ran above only need to be run once: the flag `--global` tells Git
 to use the settings for every project, in your user account, on this computer.
 
 You can check your settings at any time:

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -93,7 +93,7 @@ $ git status
 ~~~
 {: .language-bash}
 ~~~
-On branch master
+On branch main
 
 No commits yet
 

--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -78,7 +78,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -108,7 +108,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -131,7 +131,7 @@ $ git commit -m "Start notes on Mars as a base"
 {: .language-bash}
 
 ~~~
-[master (root-commit) f22b25e] Start notes on Mars as a base
+[main (root-commit) f22b25e] Start notes on Mars as a base
  1 file changed, 1 insertion(+)
  create mode 100644 mars.txt
 ~~~
@@ -161,7 +161,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 nothing to commit, working directory clean
 ~~~
 {: .output}
@@ -227,7 +227,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -290,7 +290,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -312,7 +312,7 @@ $ git commit -m "Add concerns about effects of Mars' moons on Wolfman"
 {: .language-bash}
 
 ~~~
-[master 34961b1] Add concerns about effects of Mars' moons on Wolfman
+[main 34961b1] Add concerns about effects of Mars' moons on Wolfman
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
@@ -439,7 +439,7 @@ $ git commit -m "Discuss concerns about Mars' climate for Mummy"
 {: .language-bash}
 
 ~~~
-[master 005937f] Discuss concerns about Mars' climate for Mummy
+[main 005937f] Discuss concerns about Mars' climate for Mummy
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
@@ -452,7 +452,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 nothing to commit, working directory clean
 ~~~
 {: .output}
@@ -546,7 +546,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > You can also combine the `--oneline` option with others. One useful
 > combination adds `--graph` to display the commit history as a text-based
 > graph and to indicate which commits are associated with the
-> current `HEAD`, the current branch `master`, or
+> current `HEAD`, the current branch `main`, or
 > [other Git references][git-references]:
 >
 > ~~~
@@ -554,7 +554,7 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 > ~~~
 > {: .language-bash}
 > ~~~
-> * 005937f (HEAD -> master) Discuss concerns about Mars' climate for Mummy
+> * 005937f (HEAD -> main) Discuss concerns about Mars' climate for Mummy
 > * 34961b1 Add concerns about effects of Mars' moons on Wolfman
 > * f22b25e Start notes on Mars as a base
 > ~~~
@@ -717,7 +717,7 @@ repository (`git commit`):
 > > ~~~
 > > {: .language-bash}
 > > ~~~
-> > [master cc127c2]
+> > [main cc127c2]
 > >  Write plans to start a base on Venus
 > >  2 files changed, 2 insertions(+)
 > >  create mode 100644 venus.txt

--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -191,7 +191,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -247,7 +247,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -301,7 +301,7 @@ $ git checkout HEAD mars.txt
 >
 > The "detached HEAD" is like "look, but don't touch" here,
 > so you shouldn't make any changes in this state.
-> After investigating your repo's past state, reattach your `HEAD` with `git checkout master`.
+> After investigating your repo's past state, reattach your `HEAD` with `git checkout main`.
 {: .callout}
 
 It's important to remember that

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -30,7 +30,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
@@ -76,7 +76,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
@@ -100,7 +100,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 nothing to commit, working directory clean
 ~~~
 {: .output}
@@ -130,7 +130,7 @@ $ git status --ignored
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 Ignored files:
  (use "git add -f <file>..." to include in what will be committed)
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -22,7 +22,7 @@ Systems like Git allow us to move work between any two repositories.  In
 practice, though, it's easiest to use one copy as a central hub, and to keep it
 on the web rather than on someone's laptop.  Most programmers use hosting
 services like [GitHub](https://github.com), [Bitbucket](https://bitbucket.org) or
-[GitLab](https://gitlab.com/) to hold those master copies; we'll explore the pros
+[GitLab](https://gitlab.com/) to hold those main copies; we'll explore the pros
 and cons of this in the final section of this lesson.
 
 Let's start by sharing the changes we've made to our current project with the
@@ -124,7 +124,7 @@ Once the remote is set up, this command will push the changes from
 our local repository to the repository on GitHub:
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
@@ -137,7 +137,7 @@ Writing objects: 100% (16/16), 1.45 KiB | 372.00 KiB/s, done.
 Total 16 (delta 2), reused 0 (delta 0)
 remote: Resolving deltas: 100% (2/2), done.
 To https://github.com/vlad/planets.git
- * [new branch]      master -> master
+ * [new branch]      main -> main
 ~~~
 {: .output}
 
@@ -196,19 +196,19 @@ Our local and remote repositories are now in this state:
 > option is synonymous with the `--set-upstream-to` option for the `git branch`
 > command, and is used to associate the current branch with a remote branch so
 > that the `git pull` command can be used without any arguments. To do this,
-> simply use `git push -u origin master` once the remote has been set up.
+> simply use `git push -u origin main` once the remote has been set up.
 {: .callout}
 
 We can pull changes from the remote repository to the local one as well:
 
 ~~~
-$ git pull origin master
+$ git pull origin main
 ~~~
 {: .language-bash}
 
 ~~~
 From https://github.com/vlad/planets
- * branch            master     -> FETCH_HEAD
+ * branch            main     -> FETCH_HEAD
 Already up-to-date.
 ~~~
 {: .output}
@@ -292,7 +292,7 @@ GitHub, though, this command would download them to our local repository.
 > > repository to your local repository, Git detects that they have histories that do not share a 
 > > common origin and refuses to merge.
 > > ~~~
-> > $ git pull origin master
+> > $ git pull origin main
 > > ~~~
 > > {: .language-bash}
 > >
@@ -303,8 +303,8 @@ GitHub, though, this command would download them to our local repository.
 > > remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
 > > Unpacking objects: 100% (3/3), done.
 > > From https://github.com/vlad/planets
-> >  * branch            master     -> FETCH_HEAD
-> >  * [new branch]      master     -> origin/master
+> >  * branch            main     -> FETCH_HEAD
+> >  * [new branch]      main     -> origin/main
 > > fatal: refusing to merge unrelated histories
 > > ~~~
 > > {: .output}
@@ -313,13 +313,13 @@ GitHub, though, this command would download them to our local repository.
 > > Be careful when you use this option and carefully examine the contents of local and remote 
 > > repositories before merging.
 > > ~~~
-> > $ git pull --allow-unrelated-histories origin master
+> > $ git pull --allow-unrelated-histories origin main
 > > ~~~
 > > {: .language-bash}
 > >
 > > ~~~
 > > From https://github.com/vlad/planets
-> >  * branch            master     -> FETCH_HEAD
+> >  * branch            main     -> FETCH_HEAD
 > > Merge made by the 'recursive' strategy.
 > > README.md | 1 +
 > > 1 file changed, 1 insertion(+)

--- a/_episodes/08-collab.md
+++ b/_episodes/08-collab.md
@@ -78,7 +78,7 @@ $ git commit -m "Add notes about Pluto"
 Then push the change to the *Owner's repository* on GitHub:
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
@@ -90,7 +90,7 @@ Compressing objects: 100% (2/2), done.
 Writing objects: 100% (3/3), 306 bytes, done.
 Total 3 (delta 0), reused 0 (delta 0)
 To https://github.com/vlad/planets.git
-   9272da5..29aba7c  master -> master
+   9272da5..29aba7c  main -> main
 ~~~
 {: .output}
 
@@ -137,7 +137,7 @@ Collaborator.
 To download the Collaborator's changes from GitHub, the Owner now enters:
 
 ~~~
-$ git pull origin master
+$ git pull origin main
 ~~~
 {: .language-bash}
 
@@ -148,8 +148,8 @@ remote: Compressing objects: 100% (2/2), done.
 remote: Total 3 (delta 0), reused 3 (delta 0), pack-reused 0
 Unpacking objects: 100% (3/3), done.
 From https://github.com/vlad/planets
- * branch            master     -> FETCH_HEAD
-   9272da5..29aba7c  master     -> origin/master
+ * branch            main     -> FETCH_HEAD
+   9272da5..29aba7c  main     -> origin/main
 Updating 9272da5..29aba7c
 Fast-forward
  pluto.txt | 1 +
@@ -167,10 +167,10 @@ GitHub) are back in sync.
 > repository you are collaborating on, so you should `git pull` before making
 > our changes. The basic collaborative workflow would be:
 >
-> * update your local repo with `git pull origin master`,
+> * update your local repo with `git pull origin main`,
 > * make your changes and stage them with `git add`,
 > * commit your changes with `git commit -m`, and
-> * upload the changes to GitHub with `git push origin master`
+> * upload the changes to GitHub with `git push origin main`
 >
 > It is better to make many commits with smaller changes rather than
 > of one commit with massive changes: small commits are easier to
@@ -189,9 +189,9 @@ GitHub) are back in sync.
 > command line? And on GitHub?
 >
 > > ## Solution
-> > On the command line, the Collaborator can use ```git fetch origin master```
+> > On the command line, the Collaborator can use ```git fetch origin main```
 > > to get the remote changes into the local repository, but without merging
-> > them. Then by running ```git diff master origin/master``` the Collaborator
+> > them. Then by running ```git diff main origin/main``` the Collaborator
 > > will see the changes output in the terminal.
 > >
 > > On GitHub, the Collaborator can go to the repository and click on 

--- a/_episodes/09-conflict.md
+++ b/_episodes/09-conflict.md
@@ -60,13 +60,13 @@ $ git commit -m "Add a line in our home copy"
 {: .language-bash}
 
 ~~~
-[master 5ae9631] Add a line in our home copy
+[main 5ae9631] Add a line in our home copy
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
@@ -79,7 +79,7 @@ Writing objects: 100% (3/3), 331 bytes | 331.00 KiB/s, done.
 Total 3 (delta 2), reused 0 (delta 0)
 remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
 To https://github.com/vlad/planets.git
-   29aba7c..dabb4c8  master -> master
+   29aba7c..dabb4c8  main -> main
 ~~~
 {: .output}
 
@@ -110,7 +110,7 @@ $ git commit -m "Add a line in my copy"
 {: .language-bash}
 
 ~~~
-[master 07ebc69] Add a line in my copy
+[main 07ebc69] Add a line in my copy
  1 file changed, 1 insertion(+)
 ~~~
 {: .output}
@@ -118,13 +118,13 @@ $ git commit -m "Add a line in my copy"
 but Git won't let us push it to GitHub:
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
 ~~~
 To https://github.com/vlad/planets.git
- ! [rejected]        master -> master (fetch first)
+ ! [rejected]        main -> main (fetch first)
 error: failed to push some refs to 'https://github.com/vlad/planets.git'
 hint: Updates were rejected because the remote contains work that you do
 hint: not have locally. This is usually caused by another repository pushing
@@ -143,7 +143,7 @@ What we have to do is pull the changes from GitHub,
 Let's start by pulling:
 
 ~~~
-$ git pull origin master
+$ git pull origin main
 ~~~
 {: .language-bash}
 
@@ -154,8 +154,8 @@ remote: Compressing objects: 100% (1/1), done.
 remote: Total 3 (delta 2), reused 3 (delta 2), pack-reused 0
 Unpacking objects: 100% (3/3), done.
 From https://github.com/vlad/planets
- * branch            master     -> FETCH_HEAD
-    29aba7c..dabb4c8  master     -> origin/master
+ * branch            main     -> FETCH_HEAD
+    29aba7c..dabb4c8  main     -> origin/main
 Auto-merging mars.txt
 CONFLICT (content): Merge conflict in mars.txt
 Automatic merge failed; fix conflicts and then commit the result.
@@ -223,7 +223,7 @@ $ git status
 {: .language-bash}
 
 ~~~
-On branch master
+On branch main
 All conflicts fixed but you are still merging.
   (use "git commit" to conclude merge)
 
@@ -240,14 +240,14 @@ $ git commit -m "Merge changes from GitHub"
 {: .language-bash}
 
 ~~~
-[master 2abf2b1] Merge changes from GitHub
+[main 2abf2b1] Merge changes from GitHub
 ~~~
 {: .output}
 
 Now we can push our changes to GitHub:
 
 ~~~
-$ git push origin master
+$ git push origin main
 ~~~
 {: .language-bash}
 
@@ -260,7 +260,7 @@ Writing objects: 100% (6/6), 645 bytes | 645.00 KiB/s, done.
 Total 6 (delta 4), reused 0 (delta 0)
 remote: Resolving deltas: 100% (4/4), completed with 2 local objects.
 To https://github.com/vlad/planets.git
-   dabb4c8..2abf2b1  master -> master
+   dabb4c8..2abf2b1  main -> main
 ~~~
 {: .output}
 
@@ -269,7 +269,7 @@ so we don't have to fix things by hand again
 when the collaborator who made the first change pulls again:
 
 ~~~
-$ git pull origin master
+$ git pull origin main
 ~~~
 {: .language-bash}
 
@@ -280,8 +280,8 @@ remote: Compressing objects: 100% (2/2), done.
 remote: Total 6 (delta 4), reused 6 (delta 4), pack-reused 0
 Unpacking objects: 100% (6/6), done.
 From https://github.com/vlad/planets
- * branch            master     -> FETCH_HEAD
-    dabb4c8..2abf2b1  master     -> origin/master
+ * branch            main     -> FETCH_HEAD
+    dabb4c8..2abf2b1  main     -> origin/main
 Updating dabb4c8..2abf2b1
 Fast-forward
  mars.txt | 2 +-
@@ -312,7 +312,7 @@ correctly. If you find yourself resolving a lot of conflicts in a project,
 consider these technical approaches to reducing them:
 
 - Pull from upstream more frequently, especially before starting new work
-- Use topic branches to segregate work, merging to master when complete
+- Use topic branches to segregate work, merging to main when complete
 - Make smaller more atomic commits
 - Where logically appropriate, break large files into smaller ones so that it is
   less likely that two authors will alter the same file simultaneously
@@ -373,7 +373,7 @@ Conflicts can also be minimized with project management strategies:
 > > {: .language-bash}
 > >
 > > ~~~
-> > [master 8e4115c] Add picture of Martian surface
+> > [main 8e4115c] Add picture of Martian surface
 > >  1 file changed, 0 insertions(+), 0 deletions(-)
 > >  create mode 100644 mars.jpg
 > > ~~~
@@ -384,13 +384,13 @@ Conflicts can also be minimized with project management strategies:
 > > When Dracula tries to push, he gets a familiar message:
 > >
 > > ~~~
-> > $ git push origin master
+> > $ git push origin main
 > > ~~~
 > > {: .language-bash}
 > >
 > > ~~~
 > > To https://github.com/vlad/planets.git
-> >  ! [rejected]        master -> master (fetch first)
+> >  ! [rejected]        main -> main (fetch first)
 > > error: failed to push some refs to 'https://github.com/vlad/planets.git'
 > > hint: Updates were rejected because the remote contains work that you do
 > > hint: not have locally. This is usually caused by another repository pushing
@@ -403,7 +403,7 @@ Conflicts can also be minimized with project management strategies:
 > > We've learned that we must pull first and resolve any conflicts:
 > >
 > > ~~~
-> > $ git pull origin master
+> > $ git pull origin main
 > > ~~~
 > > {: .language-bash}
 > >
@@ -411,14 +411,14 @@ Conflicts can also be minimized with project management strategies:
 > > a message like this:
 > >
 > > ~~~
-> > $ git pull origin master
+> > $ git pull origin main
 > > remote: Counting objects: 3, done.
 > > remote: Compressing objects: 100% (3/3), done.
 > > remote: Total 3 (delta 0), reused 0 (delta 0)
 > > Unpacking objects: 100% (3/3), done.
 > > From https://github.com/vlad/planets.git
-> >  * branch            master     -> FETCH_HEAD
-> >    6a67967..439dc8c  master     -> origin/master
+> >  * branch            main     -> FETCH_HEAD
+> >    6a67967..439dc8c  main     -> origin/main
 > > warning: Cannot merge binary files: mars.jpg (HEAD vs. 439dc8c08869c342438f6dc4a2b615b05b93c76e)
 > > Auto-merging mars.jpg
 > > CONFLICT (add/add): Merge conflict in mars.jpg
@@ -450,7 +450,7 @@ Conflicts can also be minimized with project management strategies:
 > > {: .language-bash}
 > >
 > > ~~~
-> > [master 21032c3] Use image of surface instead of sky
+> > [main 21032c3] Use image of surface instead of sky
 > > ~~~
 > > {: .output}
 > >
@@ -465,7 +465,7 @@ Conflicts can also be minimized with project management strategies:
 > > {: .language-bash}
 > >
 > > ~~~
-> > [master da21b34] Use image of sky instead of surface
+> > [main da21b34] Use image of sky instead of surface
 > > ~~~
 > > {: .output}
 > >
@@ -493,7 +493,7 @@ Conflicts can also be minimized with project management strategies:
 > > {: .language-bash}
 > >
 > > ~~~
-> > [master 94ae08c] Use two images: surface and sky
+> > [main 94ae08c] Use two images: surface and sky
 > >  2 files changed, 0 insertions(+), 0 deletions(-)
 > >  create mode 100644 mars-sky.jpg
 > >  rename mars.jpg => mars-surface.jpg (100%)
@@ -537,11 +537,11 @@ Conflicts can also be minimized with project management strategies:
 > >
 > > |order|action . . . . . . |command . . . . . . . . . . . . . . . . . . . |
 > > |-----|-------------------|----------------------------------------------|
-> > |1    | Update local      | `git pull origin master`                     |
+> > |1    | Update local      | `git pull origin main`                     |
 > > |2    | Make changes      | `echo 100 >> numbers.txt`                    |
 > > |3    | Stage changes     | `git add numbers.txt`                        |
 > > |4    | Commit changes    | `git commit -m "Add 100 to numbers.txt"`     |
-> > |5    | Update remote     | `git push origin master`                     |
+> > |5    | Update remote     | `git push origin main`                     |
 > > |6    | Celebrate!        | `AFK`                                        |
 > >
 > {: .solution}

--- a/_episodes/14-supplemental-rstudio.md
+++ b/_episodes/14-supplemental-rstudio.md
@@ -109,7 +109,7 @@ history:
 > Grayed out Push/Pull commands generally mean that RStudio doesn't know the
 > location of your remote repository (e.g. on GitHub). To fix this, open a
 > terminal to the repository and enter the command: `git push -u origin
-> master`. Then restart RStudio.
+> main`. Then restart RStudio.
 {: .callout}
 
 If we click on "History", we can see a graphical version of what `git log`

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -115,7 +115,8 @@ working in teams or not, because it is
 
 *   When setting up the default branch name, if learners have a Git version
     older than 2.28, the default branch name can be changed for the lesson
-    using `git branch -m master main`.
+    using `git branch -M main` if there are currently commits in the repository,
+    or `git checkout -b main` if there are no commits/the repository is completely empty.
 
 ## [Creating a Repository]({{ page.root }}{% link _episodes/03-create.md %})
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -113,6 +113,10 @@ working in teams or not, because it is
     common for them to edit the instructor's details (e.g. email).  Check at
     the end using `git config --list`.
 
+*   When setting up the default branch name, if learners have a Git version
+    older than 2.28, the default branch name can be changed for the lesson
+    using `git branch -m master main`.
+
 ## [Creating a Repository]({{ page.root }}{% link _episodes/03-create.md %})
 
 *   When you do `git status`, Mac users may see a `.DS_Store` file showing as
@@ -148,9 +152,9 @@ working in teams or not, because it is
     doing `$ git checkout f22b25e mars.txt`, someone does `$ git checkout
     f22b25e`, they wind up in the "detached HEAD" state and confusion abounds.
     It's then possible to keep on committing, but things like `git push origin
-    master` a bit later will not give easily comprehensible results.  It also
+    main` a bit later will not give easily comprehensible results.  It also
     makes it look like commits can be lost.  To "re-attach" HEAD, use
-    `git checkout master`.
+    `git checkout main`.
 
 *   This is a good moment to show a log within a Git GUI. If you skip it
     because you're short on time, show it once in GitHub.
@@ -177,11 +181,11 @@ particular set of files in `.gitignore`.
 
 *   When pushing to a remote, the output from Git can vary slightly depending on
     what leaners execute. The lesson displays the output from git if a learner
-    executes `git push origin master`. However, some learners might use syntax
+    executes `git push origin main`. However, some learners might use syntax
     suggested by GitHub for pushing to a remote with an existing repository,
-    which is `git push -u origin master`. Learners using syntax from GitHub,
-    `git push -u origin master`, will have slightly different output, including
-    the line `Branch master set up to track remote branch master from origin by rebasing.`
+    which is `git push -u origin main`. Learners using syntax from GitHub,
+    `git push -u origin main`, will have slightly different output, including
+    the line `Branch main set up to track remote branch main from origin by rebasing.`
 
 ## [Collaborating]({{ page.root }}{% link _episodes/08-collab.md %})
 


### PR DESCRIPTION
Show how to set a default branch name when configuring `git`.

Add a note in the instructor notes to change the default branch name for the
lesson if learners have a pre-2.28 Git version.

Transition from `master` to `main` as the default branch name.

Fixes #805.