### PR TITLE
add section explaining minimum SSH authentication setup for GitHub

### DIFF
--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -9,7 +9,7 @@ objectives:
 - "Push to or pull from a remote repository."
 keypoints:
 - "A local Git repository can be connected to one or more remote repositories."
-- "Use the HTTPS protocol to connect to remote repositories until you have learned how to set up SSH."
+- "Use the SSH protocol to connect to remote repositories."
 - "`git push` copies changes from a local repository to a remote repository."
 - "`git pull` copies changes from a remote repository to a local repository."
 ---
@@ -78,20 +78,10 @@ Click on the 'SSH' link to change the [protocol]({{ page.root }}{% link referenc
 
 > ## HTTPS vs. SSH
 >
-> Github used to allow command line (CLI) authentication using only username and password, which
-> uses HTTPS protocol.  However, this actually creates security risks, so, they removed 
-> the CLI username/password option.  Instead, they kept two options which provide more
-> robust security: SSH, which is a widely used protocol; and Personal Access Tokens (PAT), which uses 
-> the HTTPS protocol, and is 
-> specific to GitHub.  We will use SSH, which is described below at a minimum level for GitHub. 
-> 
-> A supplemental episode to this lesson discusses SSH and key pairs in more depth and detail, 
-> and provides details of advanced setup of SSH for GitHub.
-> Tutorials for common git cloud based services are found at 
-> [GitHub](https://help.github.com/articles/generating-ssh-keys),
-> [Atlassian/Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-ssh-for-git-728138079.html)
-> and [GitLab](https://about.gitlab.com/2014/03/04/add-ssh-key-screencast/)
-> (this one has a screencast).
+> We use SSH here because, while it requires some additional configuration, it is a 
+> security protocol widely used by many applications.  The steps below describe SSH at a 
+> minimum level for GitHub. A supplemental episode to this lesson discusses advanced setup 
+> and concepts of SSH and key pairs, and other material supplemental to git related SSH. 
 {: .callout}
 
 ![Changing the Repository URL on GitHub](../fig/github-change-repo-string.png)

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -120,7 +120,7 @@ talking about how they might be used for collaboration.
 ## SSH Background and Setup
 Before Dracula can connect to a remote repository, he needs to set up a way for his computer to authenticate with GitHub so it knows it’s him trying to connect to his remote repository. 
 
-We are going to set up the method that is commonly used by many different services to authenticate access on the command line.  This method is SSH, or secure shell protocol.  SSH is a cryptographic network protocol that allows secure communication between computers using an otherwise insecure network.  
+We are going to set up the method that is commonly used by many different services to authenticate access on the command line.  This method is called Secure Shell Protocol (SSH).  SSH is a cryptographic network protocol that allows secure communication between computers using an otherwise insecure network.  
 
 SSH uses what is called a key pair. This is two keys that work together to validate access. One key is publicly known and called the public key, and the other key called the private key is kept private. Very descriptive names.
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -192,7 +192,7 @@ Enter passphrase (empty for no passphrase):
 ~~~
 {: .output}
 
-Now, it is prompting Dracula for a passphrase.  Since he is using his lab’s laptop that other people sometimes have access to, he wants to create a passphrase.  
+Now, it is prompting Dracula for a passphrase.  Since he is using his lab’s laptop that other people sometimes have access to, he wants to create a passphrase.  Be sure to use something memorable or save your passphrase somewhere, as there is no "reset my password" option. 
 
 ~~~
 Enter same passphrase again:

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -274,7 +274,8 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDmRA3d51X0uu9wXek559gfn6UFNF69yZjChyBIU2qKI
 
 Now, going to GitHub.com, click on your profile icon in the top right corner to get the drop-down menu.  Click "settings," then on the 
 settings page, click "SSH and GPG keys," on the left side "Account settings" menu.  Click the "New SSH key" button on the right side. Now, 
-you can add the title, paste your SSH key into the field, and click the "Add SSH key" to complete the setup.
+you can add the title (Dracula uses the title "Vlad's Lab Laptop" so he can remember where the original key pair
+files are located), paste your SSH key into the field, and click the "Add SSH key" to complete the setup.
 
 Now that we’ve set that up, let’s check our authentication again from the command line. 
 ~~~

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -272,7 +272,7 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDmRA3d51X0uu9wXek559gfn6UFNF69yZjChyBIU2qKI
 ~~~
 {: .output}
 
-Now, going to GitHub.com, click on your profile icon in the top right corner to get the drop-down menu.  Click "settings," then on the 
+Now, going to GitHub.com, click on your profile icon in the top right corner to get the drop-down menu.  Click "Settings," then on the 
 settings page, click "SSH and GPG keys," on the left side "Account settings" menu.  Click the "New SSH key" button on the right side. Now, 
 you can add the title (Dracula uses the title "Vlad's Lab Laptop" so he can remember where the original key pair
 files are located), paste your SSH key into the field, and click the "Add SSH key" to complete the setup.

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -136,7 +136,7 @@ SSH uses what is called a key pair. This is two keys that work together to valid
 
 You can think of the public key as a padlock, and only you have the key (the private key) to open it. You use the public key where you want a secure method of communication, such as your GitHub account.  You give this padlock, or public key, to GitHub and say “lock the communications to my account with this so that only computers that have my private key can unlock communications and send git commands as my GitHub account.”  
 
-What we will do now is do the minimum required to set up the SSH keys and add the public key to a GitHub account.
+What we will do now is the minimum required to set up the SSH keys and add the public key to a GitHub account.
 
 > ## Advanced SSH
 > A supplemental episode in this lesson discusses SSH and key pairs in more depth and detail. 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -1,6 +1,6 @@
 ---
 title: Remotes in GitHub
-teaching: 30
+teaching: 45
 exercises: 0
 questions:
 - "How do I share my changes with others on the web?"
@@ -74,13 +74,20 @@ identify it:
 
 ![Where to Find Repository URL on GitHub](../fig/github-find-repo-string.png)
 
-Click on the 'HTTPS' link to change the [protocol]({{ page.root }}{% link reference.md %}#protocol) from SSH to HTTPS.
+Click on the 'SSH' link to change the [protocol]({{ page.root }}{% link reference.md %}#protocol) from HTTPS to SSH.
 
 > ## HTTPS vs. SSH
 >
-> We use HTTPS here because it does not require additional configuration.  After
-> the workshop you may want to set up SSH access, which is a bit more secure, by
-> following one of the great tutorials from
+> Github used to allow command line (CLI) authentication using only username and password, which
+> uses HTTPS protocol.  However, this actually creates security risks, so, they removed 
+> the CLI username/password option.  Instead, they kept two options which provide more
+> robust security: SSH, which is a widely used protocol; and Personal Access Tokens (PAT), which uses 
+> the HTTPS protocol, and is 
+> specific to GitHub.  We will use SSH, which is described below at a minimum level for GitHub. 
+> 
+> A supplemental episode to this lesson discusses SSH and key pairs in more depth and detail, 
+> and provides details of advanced setup of SSH for GitHub.
+> Tutorials for common git cloud based services are found at 
 > [GitHub](https://help.github.com/articles/generating-ssh-keys),
 > [Atlassian/Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-ssh-for-git-728138079.html)
 > and [GitLab](https://about.gitlab.com/2014/03/04/add-ssh-key-screencast/)
@@ -93,7 +100,7 @@ Copy that URL from the browser, go into the local `planets` repository, and run
 this command:
 
 ~~~
-$ git remote add origin https://github.com/vlad/planets.git
+$ git remote add origin git@github.com:vlad/planets.git
 ~~~
 {: .language-bash}
 
@@ -112,21 +119,183 @@ $ git remote -v
 {: .language-bash}
 
 ~~~
-origin   https://github.com/vlad/planets.git (push)
-origin   https://github.com/vlad/planets.git (fetch)
+origin   git@github.com:vlad/planets.git (push)
+origin   git@github.com:vlad/planets.git (fetch)
 ~~~
 {: .output}
 
 We'll discuss remotes in more detail in the next episode, while
 talking about how they might be used for collaboration.
 
-Once the remote is set up, this command will push the changes from
+## SSH Background and Setup
+Before Dracula can connect to a remote repository, he needs to set up a way for his computer to authenticate with GitHub so it knows it’s him trying to connect to his remote repository. 
+
+We are going to set up the method that is commonly used by many different services to authenticate access on the command line.  This method is SSH, or secure shell protocol.  SSH is a cryptographic network protocol that allows secure communication between computers using an otherwise insecure network.  
+
+SSH uses what is called a key pair. This is two keys that work together to validate access. One key is publicly known and called the public key, and the other key called the private key is kept private. Very descriptive names.
+
+You can think of the public key as a padlock, and only you have the key (the private key) to open it. You use the public key where you want a secure method of communication, such as your GitHub account.  You give this padlock, or public key, to GitHub and say “lock the communications to my account with this so that only computers that have my private key can unlock communications and send git commands as my GitHub account.”  
+
+What we will do now is do the minimum required to set up the SSH keys and add the public key to a GitHub account.
+
+> ## Advanced SSH
+> A supplemental episode in this lesson discusses SSH and key pairs in more depth and detail. 
+{: .callout}
+
+The first thing we are going to do is check if this has already been done on the computer you’re on.  Because generally speaking, this setup only needs to happen once and then you can forget about it. 
+
+> ## Keeping your keys secure
+> You shouldn't really forget about your SSH keys, since they keep your account secure. It’s good 
+>  practice to audit your secure shell keys every so often. Especially if you are using multiple 
+>  computers to access your account.
+{: .callout}
+
+We will run the list command to check what key pairs already exist on your computer.
+
+~~~
+ls -al ~/.ssh
+~~~
+{: .language-bash}
+
+Your output is going to look a little different depending on whether or not SSH has ever been set up on the computer you are using. 
+
+Dracula has not set up SSH on his computer, so his output is 
+
+~~~
+ls: cannot access '/c/Users/Vlad Dracula/.ssh': No such file or directory
+~~~
+{: .output}
+
+If SSH has been set up on the computer you're using, the public and private key pairs will be listed. GitHub’s key pairs use the file name `id_ed25519`, so running the `ls` command would have listed `id_ed25519` and `id_ed25519.pub` if they already existed.  
+
+Since they don’t on Dracula’s computer, he uses this command to create them: 
+
+~~~
+$ ssh-keygen -t ed25519 -C "vlad@tran.sylvan.ia"
+~~~
+{: .language-bash}
+
+~~~
+Generating public/private ed25519 key pair.
+Enter file in which to save the key (/c/Users/Vlad Dracula/.ssh/id_ed25519):
+~~~
+{: .output}
+
+We want to use the default file, so just press enter.
+
+~~~
+Created directory '/c/Users/Vlad Dracula/.ssh'.
+Enter passphrase (empty for no passphrase):
+~~~
+{: .output}
+
+Now, it is prompting Dracula for a passphrase.  Since he is using his lab’s laptop that other people sometimes have access to, he wants to create a passphrase.  
+
+~~~
+Enter same passphrase again:
+~~~
+{: .output}
+
+After entering the same passphrase a second time, we receive the confirmation
+
+~~~
+Your identification has been saved in /c/Users/Vlad Dracula/.ssh/id_ed25519
+Your public key has been saved in /c/Users/Vlad Dracula/.ssh/id_ed25519.pub
+The key fingerprint is:
+SHA256:SMSPIStNyA00KPxuYu94KpZgRAYjgt9g4BA4kFy3g1o vlad@tran.sylvan.ia
+The key's randomart image is:
++--[ED25519 256]--+
+|^B== o.          |
+|%*=.*.+          |
+|+=.E =.+         |
+| .=.+.o..        |
+|....  . S        |
+|.+ o             |
+|+ =              |
+|.o.o             |
+|oo+.             |
++----[SHA256]-----+
+~~~
+{: .output}
+
+The "identification" is actually the private key. You should never share it.  The public key is appropriately named.  The "key fingerprint" 
+is a shorter version of a public key.
+
+Now that we have generated the SSH keys, we will find the SSH files when we check.
+
+~~~
+ls -al ~/.ssh
+~~~
+{: .language-bash}
+
+~~~
+drwxr-xr-x 1 Vlad Dracula 197121   0 Jul 16 14:48 ./
+drwxr-xr-x 1 Vlad Dracula 197121   0 Jul 16 14:48 ../
+-rw-r--r-- 1 Vlad Dracula 197121 419 Jul 16 14:48 id_ed25519
+-rw-r--r-- 1 Vlad Dracula 197121 106 Jul 16 14:48 id_ed25519.pub
+~~~
+{: .output}
+
+Now we run the command to check if GitHub can read our authentication.  
+
+~~~
+ssh -T git@github.com
+~~~
+{: .language-bash}
+
+
+~~~
+The authenticity of host 'github.com (192.30.255.112)' can't be established.
+RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? y
+Please type 'yes', 'no' or the fingerprint: yes
+Warning: Permanently added 'github.com' (RSA) to the list of known hosts.
+git@github.com: Permission denied (publickey).
+~~~
+{: .output}
+
+Right, we forgot that we need to give GitHub our public key!  
+
+First, we need to copy the public key.  Be sure to include the `.pub` at the end, otherwise you’re looking at the private key. 
+
+~~~
+cat ~/.ssh/id_ed25519.pub
+~~~
+{: .language-bash}
+
+~~~
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDmRA3d51X0uu9wXek559gfn6UFNF69yZjChyBIU2qKI vlad@tran.sylvan.ia
+~~~
+{: .output}
+
+Now, going to GitHub.com, click on your profile icon in the top right corner to get the drop-down menu.  Click "settings," then on the 
+settings page, click "SSH and GPG keys," on the left side "Account settings" menu.  Click the "New SSH key" button on the right side. Now, 
+you can add the title, paste your SSH key into the field, and click the "Add SSH key" to complete the setup.
+
+Now that we’ve set that up, let’s check our authentication again from the command line. 
+~~~
+$ ssh -T git@github.com
+~~~
+{: .language-bash}
+
+~~~
+Hi Vlad! You've successfully authenticated, but GitHub does not provide shell access.
+~~~
+{: .output}
+
+## Push local changes to a remote
+
+Now that authentication is setup, we can return to the remote.  This command will push the changes from
 our local repository to the repository on GitHub:
 
 ~~~
 $ git push origin main
 ~~~
 {: .language-bash}
+
+Since Dracula set up a passphrase, it will prompt him for it.  If you completed advanced settings for your authentication, it 
+will not prompt for a passphrase. 
 
 ~~~
 Enumerating objects: 16, done.

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -119,8 +119,8 @@ $ git remote -v
 {: .language-bash}
 
 ~~~
-origin   git@github.com:vlad/planets.git (push)
 origin   git@github.com:vlad/planets.git (fetch)
+origin   git@github.com:vlad/planets.git (push)
 ~~~
 {: .output}
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -166,14 +166,17 @@ ls: cannot access '/c/Users/Vlad Dracula/.ssh': No such file or directory
 ~~~
 {: .output}
 
-If SSH has been set up on the computer you're using, the public and private key pairs will be listed. GitHub’s key pairs use the file name `id_ed25519`, so running the `ls` command would have listed `id_ed25519` and `id_ed25519.pub` if they already existed.  
+If SSH has been set up on the computer you're using, the public and private key pairs will be listed. The file names are either `id_ed25519`/`id_ed25519.pub` or `id_rsa`/`id_rsa.pub` depending on how the key pairs were set up.  
 
-Since they don’t on Dracula’s computer, he uses this command to create them: 
+Since they don’t exist on Dracula’s computer, he uses this command to create them: 
 
 ~~~
 $ ssh-keygen -t ed25519 -C "vlad@tran.sylvan.ia"
 ~~~
 {: .language-bash}
+
+If you are using a legacy system that doesn't support the Ed25519 algorithm, use:
+`$ ssh-keygen -t rsa -b 4096 -C "your_email@example.com"`
 
 ~~~
 Generating public/private ed25519 key pair.

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -184,7 +184,7 @@ Enter file in which to save the key (/c/Users/Vlad Dracula/.ssh/id_ed25519):
 ~~~
 {: .output}
 
-We want to use the default file, so just press enter.
+We want to use the default file, so just press <kbd>Enter</kbd>.
 
 ~~~
 Created directory '/c/Users/Vlad Dracula/.ssh'.


### PR DESCRIPTION
In consultation with SWC/LC git-novice lesson maintainers, the curriculum lead @tobyhodges, and after reviewing the input from the community, especially in https://github.com/swcarpentry/git-novice/issues/778, this PR adds a section in episode 7 which details and explains the minimum setup for SSH authentication connecting with GitHub.

Items which still need to occur: update screenshots, add a supplementary episode that explains and details SSH authentication in more depth, update instructor guide, update keypoint.
