### PR TITLE
Adjust nomenclature for "episode", "lesson", and "section" (fixes #777)

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -35,9 +35,9 @@ which means that any changes pushed to
 [BitBucket](https://bitbucket.org/),
 [GitLab](https://gitlab.com/) or
 another Git host server
-in a later lesson will include this information.
+after this lesson will include this information.
 
-For these lessons, we will be interacting with [GitHub](https://github.com/) and so the email address used should be the same as the one used when setting up your GitHub account. If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private][git-privacy]. 
+For this lesson, we will be interacting with [GitHub](https://github.com/) and so the email address used should be the same as the one used when setting up your GitHub account. If you are concerned about privacy, please review [GitHub's instructions for keeping your email address private][git-privacy]. 
 
 >## Keeping your email private
 >

--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -16,7 +16,7 @@ keypoints:
 - "`git checkout` recovers old versions of files."
 ---
 
-As we saw in the previous lesson, we can refer to commits by their
+As we saw in the previous episode, we can refer to commits by their
 identifiers.  You can refer to the _most recent commit_ of the working
 directory by using the identifier `HEAD`.
 

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -23,7 +23,7 @@ practice, though, it's easiest to use one copy as a central hub, and to keep it
 on the web rather than on someone's laptop.  Most programmers use hosting
 services like [GitHub](https://github.com), [Bitbucket](https://bitbucket.org) or
 [GitLab](https://gitlab.com/) to hold those main copies; we'll explore the pros
-and cons of this in the final section of this lesson.
+and cons of this in a later episode.
 
 Let's start by sharing the changes we've made to our current project with the
 world.  Log in to GitHub, then click on the icon in the top right corner to
@@ -54,7 +54,7 @@ $ git init
 ~~~
 {: .language-bash}
 
-If you remember back to the earlier [lesson](../04-changes/) where we added and
+If you remember back to the earlier [episode](../04-changes/) where we added and
 committed our earlier work on `mars.txt`, we had a diagram of the local repository
 which looked like this:
 
@@ -433,7 +433,7 @@ GitHub, though, this command would download them to our local repository.
 
 > ## Push vs. Commit
 >
-> In this lesson, we introduced the "git push" command.
+> In this episode, we introduced the "git push" command.
 > How is "git push" different from "git commit"?
 >
 > > ## Solution
@@ -445,7 +445,7 @@ GitHub, though, this command would download them to our local repository.
 
 > ## GitHub License and README files
 >
-> In this section we learned about creating a remote repository on GitHub, but when you initialized 
+> In this episode we learned about creating a remote repository on GitHub, but when you initialized 
 > your GitHub repo, you didn't add a README.md or a license file. If you had, what do you think 
 > would have happened when you tried to link your local and remote repositories?
 >

--- a/_episodes/10-open.md
+++ b/_episodes/10-open.md
@@ -97,7 +97,7 @@ by acting as a shareable electronic lab notebook for computational work:
 >
 > Anything that is hosted in a version control repository (data, code, papers, 
 > etc.) can be turned into a citable object. You'll learn how to do this in
-> [lesson 12: Citation]({{ page.root }}{% link _episodes/12-citation.md %}).
+> [the later episode on Citation]({{ page.root }}{% link _episodes/12-citation.md %}).
 {: .callout}
 
 > ## How Reproducible Is My Work?


### PR DESCRIPTION
As discussed in issue #777, some of the existing wording was inconsistent with the Carpentries' nomenclature, which could cause confusion for some. This PR adjusts the wording to be consistent, and in cases where the meaning was already or became ambiguous as a result of this change, adjusts the surrounding wording to clarify what I believe the intended meaning was. More detail on each change is in the commit log