### PR TITLE
Update 07-github.md

### DIFF
--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -443,7 +443,7 @@ GitHub, though, this command would download them to our local repository.
 > {: .solution}
 {: .challenge}
 
-> ## GitHub License and README files
+> ## Fixing "refusing to merge unrelated histories" in relation to GitHub License and README files
 >
 > In this episode we learned about creating a remote repository on GitHub, but when you initialized 
 > your GitHub repo, you didn't add a README.md or a license file. If you had, what do you think 


### PR DESCRIPTION
1) Updated challenge title to match with the challenge itself.
2) In case of the learner facing the same problem due to another reason e.g. adding another file from the web interface, the solution can now be located using the web browser's find feature CTRL+F, instead of being hidden away in the collapsed solution.

Proposed:
> ## Fixing "refusing to merge unrelated histories" in relation to GitHub License and README files

Current:
> ## GitHub License and README files
