### PR TITLE
Add numbered headers to avoid skipping steps

### DIFF
--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -26,7 +26,10 @@ services like [GitHub](https://github.com), [Bitbucket](https://bitbucket.org) o
 and cons of this in a later episode.
 
 Let's start by sharing the changes we've made to our current project with the
-world.  Log in to GitHub, then click on the icon in the top right corner to
+world. To this end we are going to create a *remote* repository that will be linked to our *local* repository.
+
+## 1. Create a remote repository
+Log in to [GitHub](https://github.com), then click on the icon in the top right corner to
 create a new repository called `planets`:
 
 ![Creating a Repository on GitHub (Step 1)](../fig/github-create-repo-01.png)
@@ -67,9 +70,10 @@ Now that we have two repositories, we need a diagram like this:
 Note that our local repository still contains our earlier work on `mars.txt`, but the
 remote repository on GitHub appears empty as it doesn't contain any files yet.
 
-The next step is to connect the two repositories.  We do this by making the
+## 2. Connect locale to remote repository
+Now we connect the two repositories.  We do this by making the
 GitHub repository a [remote]({{ page.root}}{% link reference.md %}#remote) for the local repository.
-The home page of the repository on GitHub includes the string we need to
+The home page of the repository on GitHub includes the URL string we need to
 identify it:
 
 ![Where to Find Repository URL on GitHub](../fig/github-find-repo-string.png)
@@ -117,7 +121,7 @@ origin   git@github.com:vlad/planets.git (push)
 We'll discuss remotes in more detail in the next episode, while
 talking about how they might be used for collaboration.
 
-## SSH Background and Setup
+## 3. SSH Background and Setup
 Before Dracula can connect to a remote repository, he needs to set up a way for his computer to authenticate with GitHub so it knows it’s him trying to connect to his remote repository. 
 
 We are going to set up the method that is commonly used by many different services to authenticate access on the command line.  This method is called Secure Shell Protocol (SSH).  SSH is a cryptographic network protocol that allows secure communication between computers using an otherwise insecure network.  
@@ -157,8 +161,10 @@ ls: cannot access '/c/Users/Vlad Dracula/.ssh': No such file or directory
 {: .output}
 
 If SSH has been set up on the computer you're using, the public and private key pairs will be listed. The file names are either `id_ed25519`/`id_ed25519.pub` or `id_rsa`/`id_rsa.pub` depending on how the key pairs were set up.  
+Since they don’t exist on Dracula’s computer, he uses this command to create them. 
 
-Since they don’t exist on Dracula’s computer, he uses this command to create them: 
+### 3.1 Create an SSH key pair
+To create an SSH key pair Vlad uses this command, where the `-t` option specifies which type of algorithm to use and `-C` attaches a comment to the key (here, Vlad's email):  
 
 ~~~
 $ ssh-keygen -t ed25519 -C "vlad@tran.sylvan.ia"
@@ -229,7 +235,8 @@ drwxr-xr-x 1 Vlad Dracula 197121   0 Jul 16 14:48 ../
 ~~~
 {: .output}
 
-Now we run the command to check if GitHub can read our authentication.  
+## 3.2 Copy the public key to GitHub
+Now we have a SSH key pair and we can run this command to check if GitHub can read our authentication.  
 
 ~~~
 ssh -T git@github.com
@@ -278,7 +285,9 @@ Hi Vlad! You've successfully authenticated, but GitHub does not provide shell ac
 ~~~
 {: .output}
 
-## Push local changes to a remote
+Good! This output confirms that the SSH key works as intended. We are now ready to push our work to the remote repository.
+
+## 4. Push local changes to a remote
 
 Now that authentication is setup, we can return to the remote.  This command will push the changes from
 our local repository to the repository on GitHub:

--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -70,7 +70,7 @@ Now that we have two repositories, we need a diagram like this:
 Note that our local repository still contains our earlier work on `mars.txt`, but the
 remote repository on GitHub appears empty as it doesn't contain any files yet.
 
-## 2. Connect locale to remote repository
+## 2. Connect local to remote repository
 Now we connect the two repositories.  We do this by making the
 GitHub repository a [remote]({{ page.root}}{% link reference.md %}#remote) for the local repository.
 The home page of the repository on GitHub includes the URL string we need to
@@ -235,7 +235,7 @@ drwxr-xr-x 1 Vlad Dracula 197121   0 Jul 16 14:48 ../
 ~~~
 {: .output}
 
-## 3.2 Copy the public key to GitHub
+### 3.2 Copy the public key to GitHub
 Now we have a SSH key pair and we can run this command to check if GitHub can read our authentication.  
 
 ~~~


### PR DESCRIPTION
The numbered headers are meant to improve the visibility of the steps in the procedure needed to successfully configure and use the remote repo. This change came up as a suggestion in the debriefing following a lesson during which the crucial step where the public key is copied to GitHub went unnoticed and was accidentally skipped.
