### PR TITLE
Fix images in episode 1

### DIFF
--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -17,7 +17,7 @@ to keep track of what one person did and when.
 Even if you aren't collaborating with other people,
 automated version control is much better than this situation:
 
-!["Piled Higher and Deeper" by Jorge Cham, http://www.phdcomics.com](/fig/phd101212s.png)
+!["Piled Higher and Deeper" by Jorge Cham, http://www.phdcomics.com](../fig/phd101212s.png)
 
 "Piled Higher and Deeper" by Jorge Cham, http://www.phdcomics.com
 
@@ -35,19 +35,19 @@ think of it as a recording of your progress: you can rewind to start at the base
 document and play back each change you made, eventually arriving at your
 more recent version.
 
-![Changes Are Saved Sequentially](/fig/play-changes.svg)
+![Changes Are Saved Sequentially](../fig/play-changes.svg)
 
 Once you think of changes as separate from the document itself, you
 can then think about "playing back" different sets of changes on the base document, ultimately
 resulting in different versions of that document. For example, two users can make independent
 sets of changes on the same document. 
 
-![Different Versions Can be Saved](/fig/versions.svg)
+![Different Versions Can be Saved](../fig/versions.svg)
 
 Unless multiple users make changes to the same section of the document - a conflict - you can 
 incorporate two sets of changes into the same base document.
 
-![Multiple Versions Can be Merged](/fig/merge.svg)
+![Multiple Versions Can be Merged](../fig/merge.svg)
 
 A version control system is a tool that keeps track of these changes for us,
 effectively creating different versions of our files. It allows us to decide


### PR DESCRIPTION
Fixes #850.

There might be a better fix using a "base-url" so that
urls starting in `/` work, but this should at least be
a reasonable fix, failing a cleaner solution.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
