### PR TITLE
Remove setting default editor from episode 2

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -16,7 +16,7 @@ we need to configure a few things. Below are a few examples
 of configurations we will set as we get started with Git:
 
 *   our name and email address,
-*   what our preferred text editor is,
+*   choosing how we deal with line endings in text files,
 *   and that we want to use these settings globally (i.e. for every project).
 
 On a command line, Git commands are written as `git verb options`,
@@ -74,35 +74,6 @@ For this lesson, we will be interacting with [GitHub](https://github.com/) and s
 > ~~~
 > {: .language-bash}
 > 
-{: .callout}
-
-Dracula also has to set his favorite text editor, following this table:
-
-| Editor             | Configuration command                            |
-|:-------------------|:-------------------------------------------------|
-| Atom | `$ git config --global core.editor "atom --wait"`|
-| nano               | `$ git config --global core.editor "nano -w"`    |
-| BBEdit (Mac, with command line tools) | `$ git config --global core.editor "bbedit -w"`    |
-| Sublime Text (Mac) | `$ git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl -n -w"` |
-| Sublime Text (Win, 32-bit install) | `$ git config --global core.editor "'c:/program files (x86)/sublime text 3/sublime_text.exe' -w"` |
-| Sublime Text (Win, 64-bit install) | `$ git config --global core.editor "'c:/program files/sublime text 3/sublime_text.exe' -w"` |
-| Notepad (Win)    | `$ git config --global core.editor "c:/Windows/System32/notepad.exe"`|
-| Notepad++ (Win, 32-bit install)    | `$ git config --global core.editor "'c:/program files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
-| Notepad++ (Win, 64-bit install)    | `$ git config --global core.editor "'c:/program files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`|
-| Kate (Linux)       | `$ git config --global core.editor "kate"`       |
-| Gedit (Linux)      | `$ git config --global core.editor "gedit --wait --new-window"`   |
-| Scratch (Linux)       | `$ git config --global core.editor "scratch-text-editor"`  |
-| Emacs              | `$ git config --global core.editor "emacs"`   |
-| Vim                | `$ git config --global core.editor "vim"`   |
-| VS Code                | `$ git config --global core.editor "code --wait"`   |
-
-It is possible to reconfigure the text editor for Git whenever you want to change it.
-
-> ## Exiting Vim
->
-> Note that Vim is the default editor for many programs. If you haven't used Vim before and wish to exit a session without saving
-your changes, press <kbd>Esc</kbd> then type `:q!` and hit <kbd>Return</kbd>.
-> If you want to save your changes and quit, press <kbd>Esc</kbd> then type `:wq` and hit <kbd>Return</kbd>.
 {: .callout}
 
 Git (2.28+) allows configuration of the name of the branch created when you


### PR DESCRIPTION
This change addresses #847 and recommends removing the section on setting Git's default editor from episode 2 of the lesson, with an additional small change in the initial bullet point list at the start of the lesson, replacing the reference to setting the editor with "choosing how we deal with line endings in text files". My reasoning for this change is give in my comment on the issue [here](https://github.com/swcarpentry/git-novice/issues/847#issuecomment-977867474).

I have checked the lesson still compiles and formats correctly by rebuilding and running on a local server.

This PR has been made as a contribution towards instructor training.
