### PR TITLE
Updates git clone to use SSH rather than HTTPS

### DIFF
--- a/_episodes/08-collab.md
+++ b/_episodes/08-collab.md
@@ -42,7 +42,7 @@ To clone the Owner's repo into
 her `Desktop` folder, the Collaborator enters:
 
 ~~~
-$ git clone https://github.com/vlad/planets.git ~/Desktop/vlad-planets
+$ git clone git@github.com:vlad/planets.git ~/Desktop/vlad-planets
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
For consistency with the previous episode, and avoiding authentication errors.
