### PR TITLE
Add clearer Git install instructions

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -3,15 +3,15 @@ layout: page
 title: Setup
 ---
 
-## Install Git
+## Installing Git
 Since several Carpentries lessons rely on Git, please see
 [this section of the workshop template][workshop-setup] for
 instructions on installing Git for various operating systems.
-- [Git installation on Windows][workshop-setup-windows]
-- [Git installation on MacOS][workshop-setup-macos]
-- [Git installation on Linux][workshop-setup-linux]
+- [Git installation on Windows][workshop-setup]
+- [Git installation on MacOS][workshop-setup]
+- [Git installation on Linux][workshop-setup]
 
-## Prepare Your Working Directory
+## Preparing Your Working Directory
 We'll do our work in the `Desktop` folder so make sure you change your working directory to it with:
 
 ~~~
@@ -21,6 +21,3 @@ $ cd Desktop
 {: .language-bash}
 
 [workshop-setup]: https://carpentries.github.io/workshop-template/#git
-[workshop-setup-windows]: https://carpentries.github.io/workshop-template/#git-windows
-[workshop-setup-macos]: https://carpentries.github.io/workshop-template/#git-macos
-[workshop-setup-linux]: https://carpentries.github.io/workshop-template/#git-linux

--- a/setup.md
+++ b/setup.md
@@ -3,9 +3,15 @@ layout: page
 title: Setup
 ---
 
-Please see [this section of the workshop template][workshop-setup]
-for instructions on installing Git.
+## Install Git
+Since several Carpentries lessons rely on Git, please see
+[this section of the workshop template][workshop-setup] for
+instructions on installing Git for various operating systems.
+- [Git installation on Windows][workshop-setup-windows]
+- [Git installation on MacOS][workshop-setup-macos]
+- [Git installation on Linux][workshop-setup-linux]
 
+## Prepare Your Working Directory
 We'll do our work in the `Desktop` folder so make sure you change your working directory to it with:
 
 ~~~
@@ -15,3 +21,6 @@ $ cd Desktop
 {: .language-bash}
 
 [workshop-setup]: https://carpentries.github.io/workshop-template/#git
+[workshop-setup-windows]: https://carpentries.github.io/workshop-template/#git-windows
+[workshop-setup-macos]: https://carpentries.github.io/workshop-template/#git-macos
+[workshop-setup-linux]: https://carpentries.github.io/workshop-template/#git-linux


### PR DESCRIPTION
As discussed in #781 the instructions are dominated by the instructions for preparing a directory, to the point that the instructions for installing the Git command are easily overlooked. This PR gives additional visual weight to the Git command installation, adds headers, while maintaining reference to the central instructions.

![image](https://user-images.githubusercontent.com/4656391/161393374-7d920d13-dc64-436f-a9d9-550a22a56703.png)

Potential for improvement:
- The three OS-specific links are identical. Deep-linking to the OS-specific git-windows, git-macos, and git-linux anchors only works when those are opened by default, so really only for git-windows. Furthermore, those deep links jump to the content of the box with OS-specific instructions, so the Git header and preamble in that section are not visible anymore. Ideally, #git-macos would open the menu on MacOS instructions but still link to the #git anchor. Not sure that's possible.