### PR TITLE
Changed the Line Endings git config option so it works on Windows

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -70,7 +70,7 @@ For this lesson, we will be interacting with [GitHub](https://github.com/) and s
 > And on Windows:
 >
 > ~~~
-> $ git config --global core.autocrlf true
+> $ git config --global core.autocrlf false
 > ~~~
 > {: .language-bash}
 > 


### PR DESCRIPTION
Our group noticed at a recent workshop that in Git bash for Windows, setting `git config --global core.autocrlf false` would prevent the error messages about line endings (i.e. warning: LF will be replaced by CRLF in hello.txt. The file will have its original line endings in your working directory). Currently the instructions have this option set to `true`, which does not do what we want.