### PR TITLE
Replace "forge" with service or repository

### DIFF
--- a/_episodes/13-hosting.md
+++ b/_episodes/13-hosting.md
@@ -7,7 +7,7 @@ questions:
 objectives:
 - "Explain different options for hosting scientific work."
 keypoints:
-- "Projects can be hosted on university servers, on personal domains, or on public forges."
+- "Projects can be hosted on university servers, on personal domains, or on a public hosting service."
 - "Rules regarding intellectual property and storage of sensitive information apply no matter where code and data are hosted."
 ---
 
@@ -71,7 +71,7 @@ open source projects, and are also available for private repositories for a fee.
 
 > ## Can My Work Be Public?
 >
-> Find out whether you are allowed to host your work openly on a public forge.
+> Find out whether you are allowed to host your work openly in a public repository.
 > Can you do this unilaterally,
 > or do you need permission from someone in your institution?
 > If so, who?


### PR DESCRIPTION
May I suggest a small style change?

Replace the word "forge", which may be unfamiliar to learners, with more common terms that are used in the rest of the lesson:
- "public hosting service" to describe GitHub/GitLab services in the lesson summary
- "public repository" more generally in the challenge

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
