### PR TITLE
Set appropriate format for code block in 'Exploring History' lesson 

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -327,7 +327,7 @@ here's how Git works in cartoon form:
 > ~~~
 > (use "git checkout -- <file>..." to discard changes in working directory)
 > ~~~
-> {: .language-bash}
+> {: .output}
 >
 > As it says,
 > `git checkout` without a version identifier restores files to the state saved in `HEAD`.


### PR DESCRIPTION
In the ['Exploring History' lesson under the heading 'Simplifying the Common Case'](https://swcarpentry.github.io/git-novice/05-history/index.html#simplifying-the-common-case), there is a code block which is formatted as a 'bash' command when it is clearly a (partial) 'output' instead, and the preceding text even states this:

> If you read the output of git status carefully, you’ll see that it includes this hint:

This PR changes the specification of the title and syntax highlighting scheme to render that block in the manner appropriate to its context.

I have raised a PR directly instead of reporting this as an issue since it is a trivial and uncontroversial change which is simpler to fix directly. As far as I could tell, there isn't another PR open which addresses the formatting deficiency in question.

Thanks!