### PR TITLE
IMPORTANT: Revert "Changed the Line Endings git config option so it works on Windows"

### DIFF
--- a/_episodes/02-setup.md
+++ b/_episodes/02-setup.md
@@ -70,7 +70,7 @@ For this lesson, we will be interacting with [GitHub](https://github.com/) and s
 > And on Windows:
 >
 > ~~~
-> $ git config --global core.autocrlf false
+> $ git config --global core.autocrlf true
 > ~~~
 > {: .language-bash}
 > 


### PR DESCRIPTION
Reverts swcarpentry/git-novice#880 - as it will make it hard to collaborate between different operating systems.