### PR TITLE
Remove trailing period from commit message

### DIFF
--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -94,7 +94,7 @@ Let's add and commit `.gitignore`:
 
 ~~~
 $ git add .gitignore
-$ git commit -m "Ignore data files and the results folder."
+$ git commit -m "Ignore data files and the results folder"
 $ git status
 ~~~
 {: .language-bash}


### PR DESCRIPTION
This makes the commit message consistent with the others in this lesson. It also follows the advice from
https://chris.beams.io/posts/git-commit/ , which is referred to as a guideline for commit messages.