### PR TITLE
Change output for git status to behaviour of recent git versions

### DIFF
--- a/_episodes/04-changes.md
+++ b/_episodes/04-changes.md
@@ -163,7 +163,7 @@ $ git status
 
 ~~~
 On branch main
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 
@@ -453,7 +453,7 @@ $ git status
 
 ~~~
 On branch main
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 

--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -101,7 +101,7 @@ $ git status
 
 ~~~
 On branch main
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 
@@ -139,7 +139,7 @@ Ignored files:
         c.dat
         results/
 
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -242,7 +242,7 @@ $ git status
 
 ~~~
 On branch main
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ~~~
 {: .output}
 


### PR DESCRIPTION
The output of git status changed since git v2.9.1 (https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.9.1.txt): Instead of "working directory" git status now says "working tree".

Closes #905 

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
