### PR TITLE
Update 06-ignore.md according to issue #891

### DIFF
--- a/_episodes/06-ignore.md
+++ b/_episodes/06-ignore.md
@@ -48,10 +48,17 @@ What's worse,
 having them all listed could distract us from changes that actually matter,
 so let's tell Git to ignore them.
 
-We do this by creating a file in the root directory of our project called `.gitignore`:
+We do this by creating a file in the root directory of our project called `.gitignore` and adding the text patterns we would like Git to ignore to it.
 
 ~~~
 $ nano .gitignore
+~~~
+{: .language-bash}
+
+
+After saving the `.gitignore` file, we should see the following output from `cat` command:
+
+~~~
 $ cat .gitignore
 ~~~
 {: .language-bash}


### PR DESCRIPTION
Issue #891 proposed adding some additional comments on the creation of the `.gitignore` file to clarify that learners need to add the ignore patterns to the files themselves.

