### PR TITLE
Removed reference to advanced SSH material which is still in developm…

### DIFF
--- a/episodes/07-github.md
+++ b/episodes/07-github.md
@@ -90,8 +90,7 @@ Click on the 'SSH' link to change the [protocol](../learners/reference.md#protoc
 
 We use SSH here because, while it requires some additional configuration, it is a
 security protocol widely used by many applications.  The steps below describe SSH at a
-minimum level for GitHub. A supplemental episode to this lesson discusses advanced setup
-and concepts of SSH and key pairs, and other material supplemental to git related SSH.
+minimum level for GitHub. 
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Remove reference to advanced SSH material.

In reference to issue #824 this is a suggestion to remove the reference to supplementary material for advanced SSH.  The material is not yet written or available,  but this is not clear from the text, as such learners can be searching for material that is not there.

I have left the main callout as I think the explanation of SSH is useful.