### PR TITLE
Link to installation instructions page in workshop template

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -21,7 +21,7 @@ $ cd
 $ cd Desktop
 ```
 
-[workshop-setup]: https://carpentries.github.io/workshop-template/#git
+[workshop-setup]: https://carpentries.github.io/workshop-template/install_instructions/#git
 
 
 


### PR DESCRIPTION
To reduce confusion for learners visiting the installation instructions, this links to a dedicated page of installation instructions in the template workshop website. This is instead of the template landing page, which contains a lot of FIXMEs that can be alarming and give someone the impression that the link has taken them to the wrong place.