### PR TITLE
Update 14-supplemental-rstudio.md

### DIFF
--- a/episodes/14-supplemental-rstudio.md
+++ b/episodes/14-supplemental-rstudio.md
@@ -58,7 +58,7 @@ and then type:
 - `where git` (Windows)
 
 If there is no version of Git on your computer, please follow the
-[Git installation instructions](https://swcarpentry.github.io/git-novice/setup.html)
+[Git installation instructions](https://swcarpentry.github.io/git-novice/#installing-git)
 in the setup of this lesson to install Git now. Next open your shell or command prompt
 and type `which git` (macOS, Linux), or `where git` (Windows).
 Copy the path to the git executable.


### PR DESCRIPTION
Updates a broken link to the git instruction in the section titled `### Find your Git Executable`. Fixes issue #938