### PR TITLE
Fix Windows CRLF configuration recommendation to auto.

### DIFF
--- a/episodes/02-setup.md
+++ b/episodes/02-setup.md
@@ -79,7 +79,7 @@ $ git config --global core.autocrlf input
 And on Windows:
 
 ```bash
-$ git config --global core.autocrlf false
+$ git config --global core.autocrlf true
 ```
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
Addresses #966 

_Please briefly summarize the changes made in the pull request, and the reason(s) for making these changes._
On Windows machines it is recommended in [git documentation](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf) and [GitHub docs](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#global-settings-for-line-endings) to make sure line endings are suitable for projects where collaborators work between Windows and Unix-based systems.

_If any relevant discussions have taken place elsewhere, please provide links to these._
A `.gitattributes` addition to make sure this is handled at the repository level rather than the user level (fickle) may be a good alternative or addition to this change:
https://www.edwardthomson.com/blog/git_for_windows_line_endings.html

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
