### PR TITLE
add guidance for configuring 2FA on GitHub accounts

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -12,6 +12,40 @@ instructions on installing Git for various operating systems.
 - [Git installation on MacOS][workshop-setup]
 - [Git installation on Linux][workshop-setup]
 
+## Creating a GitHub Account
+
+You will need an account for [GitHub](https://github.com) to follow episodes 7 & 8 in this lesson.
+
+1. Go to <https://github.com> and follow the "Sign up" link at the top-right of the window.
+2. Follow the instructions to create an account.
+3. Verify your email address with GitHub.
+4. Configure multifactor authentication (see below).
+
+### Multi-factor Authentication
+
+In 2023, GitHub introduced a requirement for 
+all accounts to have 
+[multi-factor authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication) 
+configured for extra security.
+Several options exist for setting up 2FA, which are summarised here:
+
+1. If you already use an authenticator app, 
+   like [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en&co=GENIE.Platform%3DiOS&oco=0) 
+   or [Duo Mobile](https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app) on your smartphone for example, 
+   [add GitHub to that app](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-mobile-app).
+2. If you have access to a smartphone but do not already use an authenticator app, install one and 
+   [add GitHub to the app](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-mobile-app).
+3. If you do not have access to a smartphone or do not want to install an authenticator app, you have two options:
+    1. [set up 2FA via text message](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages) 
+       ([list of countries where authentication by SMS is supported](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/countries-where-sms-authentication-is-supported)), or
+    2. [use a hardware security key](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-security-key) 
+       like [Youbikey](https://www.yubico.com/products/yubikey-5-overview/) 
+       or the [Google Titan key](https://store.google.com/us/product/titan_security_key?hl=en-US&pli=1).
+
+The GitHub documentation provides [more details about configuring 2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication).
+
+----------------
+
 ## Preparing Your Working Directory
 
 We'll do our work in the `Desktop` folder so make sure you change your working directory to it with:
@@ -22,6 +56,4 @@ $ cd Desktop
 ```
 
 [workshop-setup]: https://carpentries.github.io/workshop-template/install_instructions/#git
-
-
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -39,7 +39,7 @@ Several options exist for setting up 2FA, which are summarised here:
     1. [set up 2FA via text message](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages) 
        ([list of countries where authentication by SMS is supported](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/countries-where-sms-authentication-is-supported)), or
     2. [use a hardware security key](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-security-key) 
-       like [Youbikey](https://www.yubico.com/products/yubikey-5-overview/) 
+       like [YubiKey](https://www.yubico.com/products/yubikey-5-overview/) 
        or the [Google Titan key](https://store.google.com/us/product/titan_security_key?hl=en-US&pli=1).
 
 The GitHub documentation provides [more details about configuring 2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication).


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Fixes #922 

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

This adds a section to the Setup instructions about creating a GitHub account, including some guidance for learners about configuring multi-factor authentication. We are outsourcing most of the configuration instructions to GitHub themselves, as the interface and process may change relatively often.

_If any relevant discussions have taken place elsewhere, please provide links to these._

This change was discussed with Maintainers of other Git lessons in The Carpentries, and further by the @swcarpentry/curriculum-advisors.

This PR replaces #973 