### PR TITLE
Include reference to git installation from chapter 2

### DIFF
--- a/episodes/02-setup.md
+++ b/episodes/02-setup.md
@@ -17,8 +17,14 @@ exercises: 0
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::  callout
+
+## Install Git first
+
 If you got this far but haven't installed Git yet,
-[follow these installation steps first](../learners/setup.md#installing-git).
+[follow these installation steps](../learners/setup.md#installing-git).
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 When we use Git on a new computer for the first time,
 we need to configure a few things. Below are a few examples

--- a/episodes/02-setup.md
+++ b/episodes/02-setup.md
@@ -17,6 +17,9 @@ exercises: 0
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+If you got this far but haven't installed Git yet,
+[follow these installation steps first](../learners/setup.md#installing-git).
+
 When we use Git on a new computer for the first time,
 we need to configure a few things. Below are a few examples
 of configurations we will set as we get started with Git:


### PR DESCRIPTION
For any reader/learner that may have missed the Summary and Setup section of the lesson, gently guide them to the corresponding page and the installation instructions section before introducing any command. 

This PR adds a callout and link to the git installation section just before the first `git command` in chapter 2.

[Click here for a preview of the change](https://unode.github.io/git-novice/02-setup.html#install-git-first) 