### PR TITLE
Update to new private email pattern from GitHub, explain where to fin…

### DIFF
--- a/episodes/02-setup.md
+++ b/episodes/02-setup.md
@@ -48,7 +48,7 @@ For this lesson, we will be interacting with [GitHub](https://github.com/) and s
 
 ## Keeping your email private
 
-If you elect to use a private email address with GitHub, then use that same email address for the `user.email` value, e.g. `username@users.noreply.github.com` replacing `username` with your GitHub one.
+If you elect to use a private email address with GitHub, then use GitHub's no-reply email address for the `user.email` value. It looks like `ID+username@users.noreply.github.com`, you can look up your own address in your GitHub [email settings](https://github.com/settings/emails).
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/02-setup.md
+++ b/episodes/02-setup.md
@@ -48,7 +48,7 @@ For this lesson, we will be interacting with [GitHub](https://github.com/) and s
 
 ## Keeping your email private
 
-If you elect to use a private email address with GitHub, then use GitHub's no-reply email address for the `user.email` value. It looks like `ID+username@users.noreply.github.com`, you can look up your own address in your GitHub [email settings](https://github.com/settings/emails).
+If you elect to use a private email address with GitHub, then use GitHub's no-reply email address for the `user.email` value. It looks like `ID+username@users.noreply.github.com`. You can look up your own address in your GitHub [email settings](https://github.com/settings/emails).
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
…d the no-reply mail.

When going through the episode setup, I found a bit confusing that there is written

> If you elect to use a private email address with GitHub, then use that same email address for the user.email value [...]

With the example after this part of the sentence it becomes clear what is meant, but I might be inclined to put my private mail there and expose it.
Next I saw, that the pattern for these no-reply mails seems to have changed in 2017 and now has the form `ID+USERNAME@users.noreply.github.com`: https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#about-commit-email-addresses

I tried to address both of these points in this pull request. Due to the `ID` in the no-reply email, I think it now needs to be looked up and cannot be formed from the user name, that's why I included the link, let me know if this works for you.