### PR TITLE
Incorrect number of commits before head for shown output.

### DIFF
--- a/episodes/05-history.md
+++ b/episodes/05-history.md
@@ -73,7 +73,7 @@ If we want to see the differences between older commits we can use `git diff`
 again, but with the notation `HEAD~1`, `HEAD~2`, and so on, to refer to them:
 
 ```bash
-$ git diff HEAD~3 mars.txt
+$ git diff HEAD~2 mars.txt
 ```
 
 ```output

--- a/episodes/05-history.md
+++ b/episodes/05-history.md
@@ -93,7 +93,7 @@ well as the commit message, rather than the *differences* between a commit and o
 working directory that we see by using `git diff`.
 
 ```bash
-$ git show HEAD~3 mars.txt
+$ git show HEAD~2 mars.txt
 ```
 
 ```output


### PR DESCRIPTION
This pull request Closes #963 

As I followed along, the `git diff HEAD~3` on episode 5 references a commit back one commit further than my history. This leads to the output `fatal: ambiguous argument 'HEAD~3': unknown revision or path not in the working tree.`.

It is possible if a previous aside (the directories callout) is followed that this will not generate `unknown revision` issue. With this change with the directories callout skipped it will produce output that is consistent with that shown in the lesson. If the directories callout is followed, it will produce inconsistent output, however, it will not produce the "fatal" error as it does now in the situation where the "directories" callout isn't followed.

A competing solution would be to make the "directories" callout not a callout, but part of the flow of the workshop. However, in general it does seem to me that the "directories" callout really should be a callout and isn't critical to the overall flow of the lesson.
