### PR TITLE
Change settings side menu title

### DIFF
--- a/episodes/07-github.md
+++ b/episodes/07-github.md
@@ -276,7 +276,7 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDmRA3d51X0uu9wXek559gfn6UFNF69yZjChyBIU2qKI
 ```
 
 Now, going to GitHub.com, click on your profile icon in the top right corner to get the drop-down menu.  Click "Settings," then on the
-settings page, click "SSH and GPG keys," on the left side "Account settings" menu.  Click the "New SSH key" button on the right side. Now,
+settings page, click "SSH and GPG keys," on the left side "Access" menu.  Click the "New SSH key" button on the right side. Now,
 you can add the title (Dracula uses the title "Vlad's Lab Laptop" so he can remember where the original key pair
 files are located), paste your SSH key into the field, and click the "Add SSH key" to complete the setup.
 


### PR DESCRIPTION
I was looking at #990 and my account shows the same config options as the lesson but the `Account Settings` side menu subtitle is `Access` on mine. Hopefully this is the same for others and an easy change.