### PR TITLE
changes md symbol used for listing items

### DIFF
--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -202,9 +202,9 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lemon
-- salt
+* avocado
+* lemon
+* salt
 # Instructions
 ```
 
@@ -248,9 +248,9 @@ index df0654a..315bf3a 100644
 +++ b/guacamole.md
 @@ -1,2 +1,5 @@
  # Ingredients
-+- avocado
-+- lemon
-+- salt
++* avocado
++* lemon
++* salt
  # Instructions
 ```
 
@@ -358,9 +358,9 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
 ```
 
@@ -375,10 +375,10 @@ index 315bf3a..b36abfd 100644
 +++ b/guacamole.md
 @@ -1,5 +1,5 @@
  # Ingredients
- - avocado
--- lemon
-+- lime
- - salt
+ * avocado
+-* lemon
++* lime
+ * salt
  # Instructions
 ```
 
@@ -411,10 +411,10 @@ index 315bf3a..b36abfd 100644
 +++ b/guacamole.md
 @@ -1,5 +1,5 @@
  # Ingredients
- - avocado
--- lemon
-+- lime
- - salt
+ * avocado
+-* lemon
++* lime
+ * salt
  # Instructions
 ```
 
@@ -695,9 +695,9 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado (1.35)
-- lime (0.64)
-- salt (2)
+* avocado (1.35)
+* lime (0.64)
+* salt (2)
 ```
 
 ```bash
@@ -707,9 +707,9 @@ $ cat groceries.md
 
 ```output
 # Market A
-- avocado: 1.35 per unit.
-- lime: 0.64 per unit
-- salt: 2 per kg
+* avocado: 1.35 per unit.
+* lime: 0.64 per unit
+* salt: 2 per kg
 ```
 
 Now you can add both files to the staging area. We can do that in one line:

--- a/episodes/05-history.md
+++ b/episodes/05-history.md
@@ -36,9 +36,9 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
 An ill-considered change
 ```
@@ -55,8 +55,8 @@ index b36abfd..0848c8d 100644
 --- a/guacamole.md
 +++ b/guacamole.md
 @@ -3,3 +3,4 @@
- - lime
- - salt
+ * lime
+ * salt
  # Instructions
 +An ill-considered change
 ```
@@ -85,9 +85,9 @@ index df0654a..b36abfd 100644
 +++ b/guacamole.md
 @@ -1,2 +1,5 @@
  # Ingredients
-+- avocado
-+- lime
-+- salt
++* avocado
++* lime
++* salt
  # Instructions
 ```
 
@@ -146,9 +146,9 @@ index df0654a..93a3e13 100644
 +++ b/guacamole.md
 @@ -1,2 +1,5 @@
  # Ingredients
-+- avocado
-+- lime
-+- salt
++* avocado
++* lime
++* salt
  # Instructions
 +An ill-considered change
 ```
@@ -168,9 +168,9 @@ index df0654a..93a3e13 100644
 +++ b/guacamole.md
 @@ -1,2 +1,5 @@
  # Ingredients
-+- avocado
-+- lime
-+- salt
++* avocado
++* lime
++* salt
  # Instructions
 +An ill-considered change
 ```
@@ -209,9 +209,9 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
 ```
 

--- a/episodes/08-collab.md
+++ b/episodes/08-collab.md
@@ -78,10 +78,10 @@ $ cat hummus.md
 
 ```output
 # Ingredients
-- chickpeas
-- lemon
-- olive oil
-- salt
+* chickpeas
+* lemon
+* olive oil
+* salt
 ```
 
 ```bash

--- a/episodes/09-conflict.md
+++ b/episodes/09-conflict.md
@@ -34,9 +34,9 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
 ```
 
@@ -49,11 +49,11 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
-- put one avocado into a bowl.
+* put one avocado into a bowl.
 ```
 
 and then push the change to GitHub:
@@ -95,11 +95,11 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
-- peel the avocados
+* peel the avocados
 ```
 
 We can commit the change locally:
@@ -208,14 +208,14 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
 <<<<<<< HEAD
-- peel the avocados
+* peel the avocados
 =======
-- put one avocado into a bowl.
+* put one avocado into a bowl.
 >>>>>>> dabb4c8c450e8475aee9b14b4383acc99f42af1d
 ```
 
@@ -238,11 +238,11 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
-- peel the avocados and put them into a bowl.
+* peel the avocados and put them into a bowl.
 ```
 
 To finish merging,
@@ -322,11 +322,11 @@ $ cat guacamole.md
 
 ```output
 # Ingredients
-- avocado
-- lime
-- salt
+* avocado
+* lime
+* salt
 # Instructions
-- peel the avocados and put them into a bowl.
+* peel the avocados and put them into a bowl.
 ```
 
 We don't need to merge again because Git knows someone has already done that.


### PR DESCRIPTION
This is something that I always forget and only remember when I'm teaching it and encountered as recently @krishnakumarg1984 reminded me.

Markdown accepts either `-` or `*` however, in this material, the `-`
causes confusion when looking at diffs as you'd get things like:

```diff
 - avocado
-- lemon
+- lime
```

making the `-` from the diff misunderstood with the `-` of the list.