### PR TITLE
Modifies examples to include a single heading and changes md symbol used for listing items

### DIFF
--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -40,8 +40,9 @@ $ nano guacamole.md
 Type the text below into the `guacamole.md` file:
 
 ```output
-# Ingredients
-# Instructions
+# Guacamole
+## Ingredients
+## Instructions
 ```
 
 Let's first verify that the file was properly created by running the list command (`ls`):
@@ -61,8 +62,9 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
-# Instructions
+# Guacamole
+## Ingredients
+## Instructions
 ```
 
 If we check the status of our project again,
@@ -201,11 +203,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lemon
 - salt
-# Instructions
+## Instructions
 ```
 
 When we run `git status` now,
@@ -246,12 +249,13 @@ diff --git a/guacamole.md b/guacamole.md
 index df0654a..315bf3a 100644
 --- a/guacamole.md
 +++ b/guacamole.md
-@@ -1,2 +1,5 @@
- # Ingredients
+@@ -1,3 +1,6 @@
+ # Guacamole
+ ## Ingredients
 +- avocado
 +- lemon
 +- salt
- # Instructions
+ ## Instructions
 ```
 
 The output is cryptic because
@@ -357,11 +361,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 ```
 
 ```bash
@@ -373,13 +378,14 @@ diff --git a/guacamole.md b/guacamole.md
 index 315bf3a..b36abfd 100644
 --- a/guacamole.md
 +++ b/guacamole.md
-@@ -1,5 +1,5 @@
- # Ingredients
+@@ -1,6 +1,6 @@
+ # Guacamole
+ ## Ingredients
  - avocado
 -- lemon
 +- lime
  - salt
- # Instructions
+ ## Instructions
 ```
 
 So far, so good:
@@ -409,13 +415,14 @@ diff --git a/guacamole.md b/guacamole.md
 index 315bf3a..b36abfd 100644
 --- a/guacamole.md
 +++ b/guacamole.md
-@@ -1,5 +1,5 @@
- # Ingredients
+@@ -1,6 +1,6 @@
+ # Guacamole
+ ## Ingredients
  - avocado
 -- lemon
 +- lime
  - salt
- # Instructions
+ ## Instructions
 ```
 
 it shows us the difference between
@@ -694,7 +701,8 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado (1.35)
 - lime (0.64)
 - salt (2)

--- a/episodes/05-history.md
+++ b/episodes/05-history.md
@@ -35,11 +35,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 An ill-considered change
 ```
 
@@ -54,10 +55,10 @@ diff --git a/guacamole.md b/guacamole.md
 index b36abfd..0848c8d 100644
 --- a/guacamole.md
 +++ b/guacamole.md
-@@ -3,3 +3,4 @@
+@@ -4,3 +4,4 @@
  - lime
  - salt
- # Instructions
+ ## Instructions
 +An ill-considered change
 ```
 
@@ -83,12 +84,13 @@ diff --git a/guacamole.md b/guacamole.md
 index df0654a..b36abfd 100644
 --- a/guacamole.md
 +++ b/guacamole.md
-@@ -1,2 +1,5 @@
- # Ingredients
+@@ -1,3 +1,6 @@
+ # Guacamole
+ ## Ingredients
 +- avocado
 +- lime
 +- salt
- # Instructions
+ ## Instructions
 ```
 
 We could also use `git show` which shows us what changes we made at an older commit as
@@ -111,9 +113,10 @@ new file mode 100644
 index 0000000..df0654a
 --- /dev/null
 +++ b/guacamole.md
-@@ -0,0 +1,2 @@
-+# Ingredients
-+# Instructions
+@@ -0,0 +1,3 @@
++# Guacamole
++## Ingredients
++## Instructions
 ```
 
 In this way,
@@ -144,12 +147,13 @@ diff --git a/guacamole.md b/guacamole.md
 index df0654a..93a3e13 100644
 --- a/guacamole.md
 +++ b/guacamole.md
-@@ -1,2 +1,5 @@
- # Ingredients
+@@ -1,3 +1,7 @@
+ # Guacamole
+ ## Ingredients
 +- avocado
 +- lime
 +- salt
- # Instructions
+ ## Instructions
 +An ill-considered change
 ```
 
@@ -166,12 +170,13 @@ diff --git a/guacamole.md b/guacamole.md
 index df0654a..93a3e13 100644
 --- a/guacamole.md
 +++ b/guacamole.md
-@@ -1,2 +1,5 @@
- # Ingredients
+@@ -1,3 +1,7 @@
+ # Gucamole
+ ## Ingredients
 +- avocado
 +- lime
 +- salt
- # Instructions
+ ## Instructions
 +An ill-considered change
 ```
 
@@ -208,11 +213,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 ```
 
 As you might guess from its name,
@@ -232,8 +238,9 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
-# Instructions
+# Guacamole
+## Ingredients
+## Instructions
 ```
 
 ```bash

--- a/episodes/08-collab.md
+++ b/episodes/08-collab.md
@@ -77,7 +77,8 @@ $ cat hummus.md
 ```
 
 ```output
-# Ingredients
+# Hummus
+## Ingredients
 - chickpeas
 - lemon
 - olive oil
@@ -90,7 +91,7 @@ $ git commit -m "Add ingredients for hummus"
 ```
 
 ```output
- 1 file changed, 5 insertion(+)
+ 1 file changed, 6 insertion(+)
  create mode 100644 hummus.md
 ```
 

--- a/episodes/09-conflict.md
+++ b/episodes/09-conflict.md
@@ -33,11 +33,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 ```
 
 Let's add a line to the collaborator's copy only:
@@ -48,11 +49,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 - put one avocado into a bowl.
 ```
 
@@ -94,11 +96,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 - peel the avocados
 ```
 
@@ -207,11 +210,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 <<<<<<< HEAD
 - peel the avocados
 =======
@@ -237,11 +241,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 - peel the avocados and put them into a bowl.
 ```
 
@@ -321,11 +326,12 @@ $ cat guacamole.md
 ```
 
 ```output
-# Ingredients
+# Guacamole
+## Ingredients
 - avocado
 - lime
 - salt
-# Instructions
+## Instructions
 - peel the avocados and put them into a bowl.
 ```
 


### PR DESCRIPTION
As per @tobyhodges comment on https://github.com/swcarpentry/git-novice/pull/1003#pullrequestreview-2196084226

But it also includes title to make the files consistent with their filenames. (diffs were also updated accordingly)


Update (brought from #1012)
This is something that I always forget and only remember when I'm teaching it and encountered as recently @krishnakumarg1984 reminded me.

Markdown accepts either `-` or `*` however, in this material, the `-`
causes confusion when looking at diffs as you'd get things like:

```diff
 - avocado
-- lemon
+- lime
```

making the `-` from the diff misunderstood with the `-` of the list.