### PR TITLE
Fix keypoint on GPL

### DIFF
--- a/episodes/11-licensing.md
+++ b/episodes/11-licensing.md
@@ -96,7 +96,7 @@ the licenses discussed in this session? How is it different?
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - The `LICENSE`, `LICENSE.md`, or `LICENSE.txt` file is often used in a repository to indicate how the contents of the repo may be used by others.
-- People who incorporate General Public License (GPL'd) software into their own software must make their software also open under the GPL license; most other open licenses do not require this.
+- People who incorporate General Public License (GPL'd) software into their own software must make the derived software also open under the GPL license if they decide to share it; most other open licenses do not require this.
 - The Creative Commons family of licenses allow people to mix and match requirements and restrictions on attribution, creation of derivative works, further sharing, and commercialization.
 - People who are not lawyers should not try to write licenses from scratch.
 


### PR DESCRIPTION
As the GPL does not mandate sharing, putting the whole derivative under the GPL license is only required if licensees decide to share it.