### PR TITLE
Modify confusing words and add explanation to git diff with Head

### DIFF
--- a/episodes/05-history.md
+++ b/episodes/05-history.md
@@ -62,11 +62,7 @@ index b36abfd..0848c8d 100644
 +An ill-considered change
 ```
 
-which is the same as what you would get if you leave out `HEAD` (try it).  The
-real goodness in all this is when you can refer to previous commits.  We do
-that by adding `~1`
-(where "~" is "tilde", pronounced [**til**\-d*uh*])
-to refer to the commit one before `HEAD`.
+Note that `HEAD` is the default option for `git diff`, so omitting it will not change the command's output at all (give it a try). However, the real power of `git diff` lies in its ability to compare with previous commits. For example, by adding `~1` (where "~" is "tilde", pronounced [**til**\-d*uh*]), we can look at the commit before `HEAD`. 
 
 ```bash
 $ git diff HEAD~1 guacamole.md


### PR DESCRIPTION
Closes #607

Slight adjustment to the explanation of using git diff with HEAD and previous commits. The original text was great, and I've just rephrased it for clarity and consistency. The new text emphasizes that omitting HEAD doesn't change the command's output and highlights the power of comparing with previous commits using ~1.


