### PR TITLE
Align indentation in "Understanding Workflow and History" exercise

### DIFF
--- a/episodes/05-history.md
+++ b/episodes/05-history.md
@@ -406,18 +406,18 @@ $ cat ketchup.md # this will print the content of ketchup.md on screen
 ```
 
 1. ```output
-  ketchup enhances pasta dishes
-  ```
+   ketchup enhances pasta dishes
+   ```
 2. ```output
-  I like tomatoes, therefore I like ketchup
-  ```
+   I like tomatoes, therefore I like ketchup
+   ```
 3. ```output
-  I like tomatoes, therefore I like ketchup
-  ketchup enhances pasta dishes
-  ```
+   I like tomatoes, therefore I like ketchup
+   ketchup enhances pasta dishes
+   ```
 4. ```output
-  Error because you have changed ketchup.md without committing the changes
-  ```
+   Error because you have changed ketchup.md without committing the changes
+   ```
 
 :::::::::::::::  solution
 


### PR DESCRIPTION
This should fix issues with incorrect rendering of translated lessons (https://github.com/ukrainian-carpentries/git-novice/issues/2)

The change is similar to the one done by @tobyhodges in https://github.com/swcarpentry/git-novice/pull/984
