### PR TITLE
Small fixes suggested by Dimitrios

### DIFF
--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -278,7 +278,6 @@ After reviewing our change, it's time to commit it:
 
 ```bash
 $ git commit -m "Add ingredients for basic guacamole"
-$ git status
 ```
 
 ```output

--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -277,7 +277,7 @@ If we break it down into pieces:
 After reviewing our change, it's time to commit it:
 
 ```bash
-$ git commit -m "Add basic guacamole's ingredients"
+$ git commit -m "Add ingredients for basic guacamole"
 $ git status
 ```
 
@@ -298,11 +298,11 @@ Let's fix that:
 
 ```bash
 $ git add guacamole.md
-$ git commit -m "Add basic guacamole's ingredients"
+$ git commit -m "Add ingredients for basic guacamole"
 ```
 
 ```output
-[main 34961b1] Add basic guacamole's ingredient
+[main 34961b1] Add ingredients for basic guacamole
  1 file changed, 3 insertions(+)
 ```
 
@@ -467,7 +467,7 @@ commit 34961b159c27df3b475cfe4415d94a6d1fcd064d
 Author: Alfredo Linguini <a.linguini@ratatouille.fr>
 Date:   Thu Aug 22 10:07:21 2013 -0400
 
-    Add basic guacamole's ingredients
+    Add ingredients for basic guacamole
 
 commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
 Author: Alfredo Linguini <a.linguini@ratatouille.fr>
@@ -537,7 +537,7 @@ $ git log --oneline
 
 ```output
 005937f (HEAD -> main) Modify guacamole to the traditional recipe
-34961b1 Add basic guacamole's ingredients
+34961b1 Add ingredients for basic guacamole
 f22b25e Create a template for recipe
 ```
 
@@ -553,7 +553,7 @@ $ git log --oneline --graph
 
 ```output
 * 005937f (HEAD -> main) Modify guacamole to the traditional recipe
-* 34961b1 Add basic guacamole's ingredients
+* 34961b1 Add ingredients for basic guacamole
 * f22b25e Create a template for recipe
 ```
 

--- a/episodes/05-history.md
+++ b/episodes/05-history.md
@@ -434,7 +434,6 @@ the version of `ketchup.md` committed to the repository is the one from the stag
 has only one line.
 
 At this time, the working copy still has the second line (and
-
 `git status` will show that the file is modified). However, `git restore ketchup.md`
 replaces the working copy with the most recently committed version of `ketchup.md`.
 So, `cat ketchup.md` will output

--- a/episodes/06-ignore.md
+++ b/episodes/06-ignore.md
@@ -261,7 +261,7 @@ receipts/plots
 ```
 
 What's the shortest `.gitignore` rule you could write to ignore all `.dat`
-files in `result/data/market_position/gps`? Do not ignore the `info.txt`.
+files in `receipts/data/market_position/gps`? Do not ignore the `info.txt`.
 
 :::::::::::::::  solution
 

--- a/episodes/06-ignore.md
+++ b/episodes/06-ignore.md
@@ -199,9 +199,9 @@ You would add the following two lines to your .gitignore:
 
 The exclamation point operator will include a previously excluded entry.
 
-Note also that because you've previously committed `.png` files in this
-lesson they will not be ignored with this new rule. Only future additions
-of `.png` files added to the root directory will be ignored.
+Note also that, if you've previously committed `.png` files in this
+lesson, they will not be ignored with this new rule. Only future additions
+of `.png` files to the root directory will be ignored.
 
 
 

--- a/learners/discuss.md
+++ b/learners/discuss.md
@@ -367,7 +367,7 @@ If you forgot to use Git and you used Unix `mv` instead
 of `git mv`, you will have a touch more work to do but Git will
 be able to deal with it. Let's try again renaming the file,
 this time with Unix `mv`. First, we need to recreate the
-`krypton.txt` file:
+`whitesauce.md` file:
 
 ```bash
 $ echo "Very fun recipe to do" > whitesauce.md
@@ -375,7 +375,7 @@ $ git add whitesauce.md
 $ git commit -m 'Add white sauce recipe'
 ```
 
-Let us rename the file and see what Git can figured out by itself:
+Let us rename the file and see what Git can figure out by itself:
 
 ```bash
 $ mv whitesauce.md bechamel.md


### PR DESCRIPTION
Fixes #1041, fixes #1045, fixes #1047, fixes #1044, issues raised by @astroDimitrios.

Additionally:
- the wording "Add basic guacamole's ingredients" has been adjusted to "Add ingredients for basic guacamole"
- a spurious lines has been removed from episode 5
- a typo has been fixed in the discussion.