### PR TITLE
include global flag for config list command

### DIFF
--- a/episodes/02-setup.md
+++ b/episodes/02-setup.md
@@ -161,7 +161,7 @@ Let's close the file without making any additional changes.  Remember, since typ
 issues, it's safer to view the configuration with:
 
 ```bash
-$ git config --list
+$ git config --list --global
 ```
 
 And if necessary, change your configuration using the


### PR DESCRIPTION
Closes #907

Using global flag to write config, we should use it read config.