### PR TITLE
Disambiguate initial commit message for Guacamole recipe

### DIFF
--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -27,7 +27,7 @@ You should be in the `recipes` directory.
 $ cd ~/Desktop/recipes
 ```
 
-Let's create a file called `guacamole.md` that contains the basic structure of a recipe.
+Let's create a file called `guacamole.md` that contains the basic structure of our first recipe.
 We'll use `nano` to edit the file;
 you can use whatever editor you like.
 In particular, this does not have to be the `core.editor` you set globally earlier. But remember, the steps to create or edit a new file will depend on the editor you choose (it might not be nano). For a refresher on text editors, check out ["Which Editor?"](https://swcarpentry.github.io/shell-novice/03-create.html#which-editor) in [The Unix Shell](https://swcarpentry.github.io/shell-novice/) lesson.
@@ -118,11 +118,11 @@ To get it to do that,
 we need to run one more command:
 
 ```bash
-$ git commit -m "Create a template for recipe"
+$ git commit -m "Create initial structure for a Guacamole recipe"
 ```
 
 ```output
-[main (root-commit) f22b25e] Create a template for recipe
+[main (root-commit) f22b25e] Create initial structure for a Guacamole recipe
  1 file changed, 1 insertion(+)
  create mode 100644 guacamole.md
 ```
@@ -167,7 +167,7 @@ commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
 Author: Alfredo Linguini <a.linguini@ratatouille.fr>
 Date:   Thu Aug 22 09:51:46 2013 -0400
 
-    Create a template for recipe
+    Create initial structure for a Guacamole recipe
 ```
 
 `git log` lists all commits  made to a repository in reverse chronological order.
@@ -471,7 +471,7 @@ commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
 Author: Alfredo Linguini <a.linguini@ratatouille.fr>
 Date:   Thu Aug 22 09:51:46 2013 -0400
 
-    Create a template for recipe
+    Create initial structure for a Guacamole recipe
 ```
 
 :::::::::::::::::::::::::::::::::::::::::  callout
@@ -536,7 +536,7 @@ $ git log --oneline
 ```output
 005937f (HEAD -> main) Modify guacamole to the traditional recipe
 34961b1 Add ingredients for basic guacamole
-f22b25e Create a template for recipe
+f22b25e Create initial structure for a Guacamole recipe
 ```
 
 You can also combine the `--oneline` option with others. One useful
@@ -552,7 +552,7 @@ $ git log --oneline --graph
 ```output
 * 005937f (HEAD -> main) Modify guacamole to the traditional recipe
 * 34961b1 Add ingredients for basic guacamole
-* f22b25e Create a template for recipe
+* f22b25e Create initial structure for a Guacamole recipe
 ```
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Fixes https://github.com/swcarpentry/git-novice/issues/1073

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

Instead of using the term *template*, the episode explicitly states in the initial commit message that it is the initial structure for our first recipe, being a Guacamole recipe.

_If any relevant discussions have taken place elsewhere, please provide links to these._

This topic came up in my teaching demo today, where @dpshelio suggested I propose a change, following what I did (in initially creating a file `template.md`). Contemplating a bit, this adds more action items to the episode, so I would now propose to rather fix the initial commit message instead, keeping the overall number of action items in the episode the same.

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
