### PR TITLE
Update 06-ignore.md (minor edit)

### DIFF
--- a/episodes/06-ignore.md
+++ b/episodes/06-ignore.md
@@ -130,7 +130,7 @@ Use -f if you really want to add them.
 
 If we really want to override our ignore settings,
 we can use `git add -f` to force Git to add something. For example,
-`git add -f a.csv`.
+`git add -f a.png`.
 We can also always see the status of ignored files if we want:
 
 ```bash


### PR DESCRIPTION
This PR contains a tiny edit, changing "a.csv" to "a.png", in an explanation on adding exemptions to files being ignored. This change is suggested to better align with the storyline of the explanation that is being given about .gitignore. The .png files are in the example being ignored. Therefore it seems more logical to me to explain how the exemption works also with a .png file, instead of a non existing .csv file.