### PR TITLE
Add note on 'git restore' to Instructor Notes

### DIFF
--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -158,6 +158,10 @@ working in teams or not, because it is
 - This is a good moment to show a log within a Git GUI. If you skip it
   because you're short on time, show it once in GitHub.
 
+## [Exploring History](../episodes/05-history.md)
+
+- Git 2.23 (August 2019) added the `git restore` command as a clearer, more verbose replacement for the heavily overloaded `git checkout` when you wish to restore files into the working tree. The older style `git checkout -- file` does still work in newer versions of Git. This is an illustration of the fact that there are often multiple ways to do the same thing in Git.
+
 ## [Ignoring Things](../episodes/06-ignore.md)
 
 Just remember that you can use wildcards and regular expressions to ignore a


### PR DESCRIPTION

This PR addresses issue #1020 by adding a note on `git restore` to `instructor-notes.md` clarifying its relation to `git checkout`.

Info on these changes can be found [here](https://www.infoq.com/news/2019/08/git-2-23-switch-restore), [here](https://stackoverflow.com/questions/61130412/what-is-the-difference-between-git-checkout-vs-git-restore-for-reverting-un), and in Git's [release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.23.0.adoc).

`git switch` is not mentioned in the lesson to the best of my knowledge so I didn't mention it even though it was introduced at the same time as `git restore`.