### PR TITLE
Fixing figures in dark-mode 

### DIFF
--- a/episodes/01-basics.md
+++ b/episodes/01-basics.md
@@ -22,7 +22,7 @@ to keep track of what one person did and when.
 Even if you aren't collaborating with other people,
 automated version control is much better than this situation:
 
-!["notFinal.doc" by Jorge Cham, <https://www.phdcomics.com>](fig/phd101212s.png){alt='Comic: a PhD student sends "FINAL.doc" to their supervisor, but after several increasingly intense and frustrating rounds of comments and revisions they end up with a file named "FINAL_rev.22.comments49.corrections.10.#@$%WHYDIDCOMETOGRADSCHOOL????.doc"'}
+!["notFinal.doc" by Jorge Cham, <https://www.phdcomics.com>](fig/phd101212s.png){alt='Comic: a PhD student sends "FINAL.doc" to their supervisor, but after several increasingly intense and frustrating rounds of comments and revisions they end up with a file named "FINAL_rev.22.comments49.corrections.10.#@$%WHYDIDCOMETOGRADSCHOOL????.doc"' style="filter:invert(0);"}
 
 We've all been in this situation before: it seems unnecessary to have
 multiple nearly-identical versions of the same document. Some word
@@ -38,20 +38,20 @@ think of it as a recording of your progress: you can rewind to start at the base
 document and play back each change you made, eventually arriving at your
 more recent version.
 
-![](fig/play-changes.svg){alt='A diagram demonstrating how a single document grows as the result of sequential changes'}
+![](fig/play-changes.svg){alt='A diagram demonstrating how a single document grows as the result of sequential changes' style="filter:invert(0);"}
 
 Once you think of changes as separate from the document itself, you
 can then think about "playing back" different sets of changes on the base document, ultimately
 resulting in different versions of that document. For example, two users can make independent
 sets of changes on the same document.
 
-![](fig/versions.svg){alt='A diagram with one source document that has been modified in two different ways to produce two different versions of the document'}
+![](fig/versions.svg){alt='A diagram with one source document that has been modified in two different ways to produce two different versions of the document' style="filter:invert(0);"}
 
 Unless multiple users make changes to the same section of the document - a 
 [conflict](../learners/reference.md#conflict) - you can
 incorporate two sets of changes into the same base document.
 
-![](fig/merge.svg){alt='A diagram that shows the merging of two different document versions into one document that contains all of the changes from both versions'}
+![](fig/merge.svg){alt='A diagram that shows the merging of two different document versions into one document that contains all of the changes from both versions' style="filter:invert(0);"}
 
 A version control system is a tool that keeps track of these changes for us,
 effectively creating different versions of our files. It allows us to decide

--- a/episodes/09-conflict.md
+++ b/episodes/09-conflict.md
@@ -134,7 +134,7 @@ hint: (e.g., 'git pull ...') before pushing again.
 hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 ```
 
-![](fig/conflict.svg){alt='A diagram showing a conflict that might occur when two sets of independent changes are merged'}
+![](fig/conflict.svg){alt='A diagram showing a conflict that might occur when two sets of independent changes are merged' style="filter:invert(0);"}
 
 Git rejects the push because it detects that the remote repository has new updates that have not been
 incorporated into the local branch.


### PR DESCRIPTION
Hi,

when switching to dark-mode (in different browsers, ie. MS Edge and Firefox) images are "inverted".
While this is fine for most, some images of your tutorial are getting less illustrating in my opinion:

<img width="444" height="749" alt="grafik" src="https://github.com/user-attachments/assets/4da8b3b2-4742-45c0-89cf-135ea914b056" />

The only fix I found was to counter the CSS-induced "color invertion" with a dedicated CSS-statement for images that are to be kept in original coloring also in dark mode, i.e. adding `style="filter:invert(0);"` within the image's Markdown code.

I changed the invertion for

- the comic
- the 3 SVG images explaing changes in e01
- the SVG explaining merging in e09

Hope that helps.

Best,
Martin

