### PR TITLE
Update git diff explanation in history.md

### DIFF
--- a/episodes/05-history.md
+++ b/episodes/05-history.md
@@ -62,7 +62,7 @@ index b36abfd..0848c8d 100644
 +An ill-considered change
 ```
 
-Note that `HEAD` is the default option for `git diff`, so omitting it will not change the command's output at all (give it a try). However, the real power of `git diff` lies in its ability to compare with previous commits. For example, by adding `~1` (where "~" is "tilde", pronounced [**til**\-d*uh*]), we can look at the commit before `HEAD`.
+Note that `HEAD` is the default option for `git diff` if there is no staged version, so omitting it will not change the command's output at all in this case (give it a try). If a staged file has been further modified, however, it will compare the modified version to the staged version (try adding guacamole.md to the staged area, making an additional modification, then running `git diff` and `git diff HEAD` again). In any case, the real power of `git diff` lies in its ability to compare with previous commits. For example, by adding `~1` (where "~" is "tilde", pronounced [**til**\-d*uh*]), we can look at the commit before `HEAD`.
 
 ```bash
 $ git diff HEAD~1 guacamole.md


### PR DESCRIPTION
Clarified the explanation of the default option for 'git diff' and its behavior with staged files.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

The Exploring History lesson asserted that HEAD was the default option for 'git diff', which is only true if the staging area is empty. If there are staged changes, 'git diff' compares the working area to the staged area, and adding HEAD will give a different result.

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
