### PR TITLE
Modify the solution to Conflicts on Non-textual Files challenge so that it is more consistent with the intended behavior

### DIFF
--- a/episodes/09-conflict.md
+++ b/episodes/09-conflict.md
@@ -504,7 +504,7 @@ image and rename it:
 
 ```bash
 $ git checkout HEAD guacamole.jpg
-$ git mv guacamole.jpg guacamole-only.jpg
+$ mv guacamole.jpg guacamole-only.jpg
 $ git checkout 439dc8c0 guacamole.jpg
 $ mv guacamole.jpg guacamole-nachos.jpg
 ```


### PR DESCRIPTION
When trying to keep both images in this challenge, the original solution suggests using "git mv" for renaming one conflicted image file, but only "mv" for another.

Using "mv" in both cases will be more consistent and still correct, while preventing git from auto-resolving the conflict and barring a "git checkout" navigation to the alternate path -- it happens sometimes.

The original solution should still work in some cases, but the updated solution should work in all cases.